### PR TITLE
Prevent stale PWA assets from loading on planarity web build

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -33,6 +33,35 @@
 
   <title>planarity</title>
   <link rel="manifest" href="manifest.json">
+  <script>
+    (function () {
+      if (!('serviceWorker' in navigator)) {
+        return;
+      }
+
+      window.__pwaCleanup = (async function () {
+        try {
+          const registrations = await navigator.serviceWorker.getRegistrations();
+          await Promise.all(
+            registrations.map(async function (registration) {
+              try {
+                await registration.unregister();
+              } catch (_) {}
+            })
+          );
+
+          if ('caches' in window) {
+            const cacheNames = await caches.keys();
+            await Promise.all(
+              cacheNames.map(function (cacheName) {
+                return caches.delete(cacheName);
+              })
+            );
+          }
+        } catch (_) {}
+      })();
+    })();
+  </script>
 </head>
 <body>
   <!--
@@ -43,6 +72,16 @@
     For more details:
     * https://docs.flutter.dev/platform-integration/web/initialization
   -->
-  <script src="flutter_bootstrap.js" async></script>
+  <script>
+    window.addEventListener('load', async function () {
+      if (window.__pwaCleanup) {
+        await window.__pwaCleanup;
+      }
+      const scriptTag = document.createElement('script');
+      scriptTag.src = 'flutter_bootstrap.js';
+      scriptTag.async = true;
+      document.body.appendChild(scriptTag);
+    });
+  </script>
 </body>
 </html>

--- a/web/service-worker.js
+++ b/web/service-worker.js
@@ -1,0 +1,31 @@
+self.addEventListener('install', function () {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', function (event) {
+  event.waitUntil(
+    (async function () {
+      try {
+        const cacheNames = await caches.keys();
+        await Promise.all(
+          cacheNames.map(function (cacheName) {
+            return caches.delete(cacheName);
+          })
+        );
+      } catch (_) {}
+
+      await self.registration.unregister();
+
+      const clients = await self.clients.matchAll({
+        includeUncontrolled: true,
+        type: 'window',
+      });
+
+      await Promise.all(
+        clients.map(function (client) {
+          return client.navigate(client.url);
+        })
+      );
+    })()
+  );
+});

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,0 +1,31 @@
+self.addEventListener('install', function () {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', function (event) {
+  event.waitUntil(
+    (async function () {
+      try {
+        const cacheNames = await caches.keys();
+        await Promise.all(
+          cacheNames.map(function (cacheName) {
+            return caches.delete(cacheName);
+          })
+        );
+      } catch (_) {}
+
+      await self.registration.unregister();
+
+      const clients = await self.clients.matchAll({
+        includeUncontrolled: true,
+        type: 'window',
+      });
+
+      await Promise.all(
+        clients.map(function (client) {
+          return client.navigate(client.url);
+        })
+      );
+    })()
+  );
+});


### PR DESCRIPTION
Summary
- add cleanup logic that unregisters any legacy service workers and clears caches before bootstrapping Flutter
- defer loading `flutter_bootstrap.js` until after cleanup ensures users coming from the old Next.js PWA load the current app
- add service worker scripts that uninstall themselves, drop caches, and refresh clients to force the new build

Testing
- Not run (not requested)