### PR TITLE
Improve Firebase auth diagnostics and macOS signing setup

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,7 +31,9 @@ Future<bool> _initializeFirebase() async {
       options: DefaultFirebaseOptions.currentPlatform,
     );
     return true;
-  } catch (_) {
+  } catch (error, stackTrace) {
+    debugPrint('Firebase initialization failed: $error');
+    debugPrintStack(stackTrace: stackTrace);
     return false;
   }
 }
@@ -464,11 +466,21 @@ class _PlanarityHomePageState extends State<PlanarityHomePage> {
         }
       }
       return null;
-    } on FirebaseAuthException catch (error) {
+    } on FirebaseAuthException catch (error, stackTrace) {
+      debugPrint(
+        'Firebase auth failed: code=${error.code}, message=${error.message}',
+      );
+      debugPrintStack(stackTrace: stackTrace);
       return _authErrorMessage(error);
-    } on FirebaseException catch (_) {
+    } on FirebaseException catch (error, stackTrace) {
+      debugPrint(
+        'Firebase auth config failed: code=${error.code}, message=${error.message}',
+      );
+      debugPrintStack(stackTrace: stackTrace);
       return 'auth configuration is missing';
-    } catch (_) {
+    } catch (error, stackTrace) {
+      debugPrint('Unexpected auth failure: $error');
+      debugPrintStack(stackTrace: stackTrace);
       return 'unable to authenticate right now';
     }
   }
@@ -498,6 +510,13 @@ class _PlanarityHomePageState extends State<PlanarityHomePage> {
         return 'invalid email or password';
       case 'too-many-requests':
         return 'too many attempts. try again later';
+      case 'operation-not-allowed':
+        return 'email/password sign-in is not enabled';
+      case 'app-not-authorized':
+      case 'invalid-api-key':
+        return 'auth configuration is invalid for this app';
+      case 'keychain-error':
+        return 'macos keychain access is not configured';
       case 'network-request-failed':
         return 'network error. check your connection';
       default:

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -122,7 +122,6 @@
 				D3A2B9817AD89EA45E198648 /* Pods-RunnerTests.release.xcconfig */,
 				169FC4E3CDC9026902C880EE /* Pods-RunnerTests.profile.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -576,8 +575,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = A4495KV2T9;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -708,8 +709,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = A4495KV2T9;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -728,8 +731,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Release.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = A4495KV2T9;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -6,7 +6,13 @@
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)$(CFBundleIdentifier)</string>
+	</array>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -4,5 +4,11 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)$(CFBundleIdentifier)</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Summary
- add detailed logging for Firebase initialization and authentication failures plus new user-facing error strings for more specific codes
- enable required macOS signing entitlements and development team settings so Runner can sign without manual setup
- grant network and keychain entitlements (including access groups) needed for Firebase auth on macOS

Testing
- Not run (not requested)