### PR TITLE
Fix daily graph generation to be deterministic across devices

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2900,10 +2900,9 @@ class PlanarityLevel {
 class PlanarityGenerator {
   static PlanarityLevel generate({required String dayKey, required int level}) {
     final nodeCount = max(2, level);
-    final structureRandom = Random(_stableSeed(dayKey, level));
-    final embedding = _circleLayout(nodeCount);
-    final edges = _buildPlanarEdges(embedding, structureRandom);
-    final positionsRandom = Random(_stableSeed(dayKey, 0));
+    final structureRandom = _DeterministicRandom(_stableSeed(dayKey, nodeCount));
+    final edges = _buildPlanarEdges(nodeCount, structureRandom);
+    final positionsRandom = _DeterministicRandom(_stableSeed(dayKey, nodeCount));
     final scattered = _scatterNodes(nodeCount, positionsRandom);
 
     if (nodeCount >= 4 && edges.isNotEmpty) {
@@ -2919,30 +2918,18 @@ class PlanarityGenerator {
     return PlanarityLevel(nodes: scattered, edges: edges);
   }
 
-  static List<Offset> _circleLayout(int n) {
-    if (n == 1) {
-      return const [Offset(0, 0)];
-    }
-
-    return List.generate(n, (i) {
-      final angle = (2 * pi * i) / n;
-      return Offset(cos(angle), sin(angle));
-    });
-  }
-
-  static List<Offset> _scatterNodes(int n, Random random) {
+  static List<Offset> _scatterNodes(int n, _DeterministicRandom random) {
     return List.generate(n, (_) => _randomPoint(random));
   }
 
-  static Offset _randomPoint(Random random) {
+  static Offset _randomPoint(_DeterministicRandom random) {
     return Offset(
       50 + random.nextDouble() * 260,
       60 + random.nextDouble() * 420,
     );
   }
 
-  static List<Edge> _buildPlanarEdges(List<Offset> embedding, Random random) {
-    final n = embedding.length;
+  static List<Edge> _buildPlanarEdges(int n, _DeterministicRandom random) {
     if (n <= 1) {
       return const <Edge>[];
     }
@@ -2963,18 +2950,13 @@ class PlanarityGenerator {
       }
     }
 
-    candidates.shuffle(random);
+    _shuffleEdges(candidates, random);
     for (final candidate in candidates) {
       final crossesExisting = edges.any((existing) {
         if (existing.sharesNode(candidate)) {
           return false;
         }
-        return _segmentsIntersect(
-          embedding[candidate.a],
-          embedding[candidate.b],
-          embedding[existing.a],
-          embedding[existing.b],
-        );
+        return _crossesInConvexOrder(candidate, existing, n);
       });
       if (!crossesExisting && random.nextDouble() < 0.55) {
         edges.add(candidate);
@@ -2982,6 +2964,34 @@ class PlanarityGenerator {
     }
 
     return edges.toList(growable: false);
+  }
+
+  static void _shuffleEdges(List<Edge> edges, _DeterministicRandom random) {
+    for (var i = edges.length - 1; i > 0; i--) {
+      final swapIndex = random.nextInt(i + 1);
+      final current = edges[i];
+      edges[i] = edges[swapIndex];
+      edges[swapIndex] = current;
+    }
+  }
+
+  // For vertices placed in a consistent cyclic order on a convex polygon,
+  // two edges cross iff their endpoints interleave around the polygon.
+  static bool _crossesInConvexOrder(Edge a, Edge b, int nodeCount) {
+    final aToBStart = _isBetweenClockwise(start: a.a, value: b.a, end: a.b, nodeCount: nodeCount);
+    final aToBEnd = _isBetweenClockwise(start: a.a, value: b.b, end: a.b, nodeCount: nodeCount);
+    return aToBStart != aToBEnd;
+  }
+
+  static bool _isBetweenClockwise({
+    required int start,
+    required int value,
+    required int end,
+    required int nodeCount,
+  }) {
+    final relativeValue = (value - start + nodeCount) % nodeCount;
+    final relativeEnd = (end - start + nodeCount) % nodeCount;
+    return relativeValue > 0 && relativeValue < relativeEnd;
   }
 
   // Stable seed hash (FNV-1a style) to keep generation consistent across runs/platforms.
@@ -2993,6 +3003,22 @@ class PlanarityGenerator {
       hash = (hash * 0x01000193) & 0x7fffffff;
     }
     return hash;
+  }
+}
+
+class _DeterministicRandom {
+  _DeterministicRandom(int seed) : _state = seed & 0xffffffff;
+
+  int _state;
+
+  int nextInt(int max) {
+    assert(max > 0, 'max must be positive');
+    return (nextDouble() * max).floor();
+  }
+
+  double nextDouble() {
+    _state = (_state * 1664525 + 1013904223) & 0xffffffff;
+    return _state / 0x100000000;
   }
 }
 

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -11,11 +11,38 @@ String _todayKey() {
   return '$year-$month-$day';
 }
 
+String _graphSignature(PlanarityLevel level) {
+  final nodeSignature = level.nodes
+      .map((node) => '${node.dx.toStringAsFixed(6)},${node.dy.toStringAsFixed(6)}')
+      .join('|');
+  final edgeSignature = level.edges.map((edge) => '${edge.a}-${edge.b}').join('|');
+  return '$nodeSignature::$edgeSignature';
+}
+
 void main() {
   test('score updates when a graph is solved', () {
     expect(scoreForSolvedLevel(level: 6, movesUsed: 2), 4);
     expect(scoreForSolvedLevel(level: 6, movesUsed: 6), 0);
     expect(scoreForSolvedLevel(level: 6, movesUsed: 8), 0);
+  });
+
+  test('daily graph generation is deterministic for the same day and node count', () {
+    final first = PlanarityGenerator.generate(dayKey: '2026-03-18', level: 6);
+    final second = PlanarityGenerator.generate(dayKey: '2026-03-18', level: 6);
+    final equivalentNodeCount = PlanarityGenerator.generate(dayKey: '2026-03-18', level: 2);
+    final equivalentNodeCountAgain = PlanarityGenerator.generate(dayKey: '2026-03-18', level: 1);
+
+    expect(_graphSignature(first), _graphSignature(second));
+    expect(_graphSignature(equivalentNodeCount), _graphSignature(equivalentNodeCountAgain));
+  });
+
+  test('daily graph generation changes when the day or node count changes', () {
+    final baseline = PlanarityGenerator.generate(dayKey: '2026-03-18', level: 6);
+    final differentDay = PlanarityGenerator.generate(dayKey: '2026-03-19', level: 6);
+    final differentNodeCount = PlanarityGenerator.generate(dayKey: '2026-03-18', level: 7);
+
+    expect(_graphSignature(baseline), isNot(_graphSignature(differentDay)));
+    expect(_graphSignature(baseline), isNot(_graphSignature(differentNodeCount)));
   });
 
   testWidgets('Home page shows mobile leaderboard with global default', (


### PR DESCRIPTION
## Summary
- replace runtime-dependent `Random` usage in `PlanarityGenerator` with an app-owned deterministic RNG
- seed graph structure and node placement from the UTC day key and node count so the same daily graph is generated on all devices
- replace shuffle and crossing checks with deterministic implementations that do not depend on platform behavior
- add regression tests covering stable generation for the same day/node count and variation across different days or node counts

## Testing
- Not run (not requested)