### PR TITLE
Fix friends leaderboard lock status (#82)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3852,6 +3852,10 @@ int _leaderboardRawScoreFromData(Map<String, dynamic>? profileData) {
 }
 
 bool _leaderboardLockedFromData(Map<String, dynamic>? profileData) {
+  final playedToday = profileData?['lastPlayed'] == _leaderboardTodayKey();
+  if (!playedToday) {
+    return false;
+  }
   final locked = profileData?['locked'];
   if (locked is bool) {
     return locked;

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,8 +1,8 @@
-import 'dart:ui';
 import 'dart:convert';
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:planarity/main.dart';
@@ -326,6 +326,7 @@ void main() {
 
     expect(find.text('daily score'), findsOneWidget);
     expect(find.text('0'), findsOneWidget);
+    expect(find.byIcon(FontAwesomeIcons.lock), findsNothing);
     expect(find.text('start'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- Only show leaderboard lock status when the profile is locked for the current daily play date.
- Added regression coverage for stale locked local state resetting to score 0 without showing a lock icon.

Closes #82

## Verification
- `dart format lib/main.dart test/widget_test.dart` - passed
- `flutter analyze` - failed: 59 pre-existing info-level issues in `lib/main.dart`; no new analyzer issues from this change after removing the test import lint
- `flutter test test/widget_test.dart` - passed