### PR TITLE
Fix mobile invite link redirect (#81)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -23,6 +23,9 @@
               android:name="io.flutter.embedding.android.NormalTheme"
               android:resource="@style/NormalTheme"
               />
+            <meta-data
+                android:name="flutter_deeplinking_enabled"
+                android:value="false" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -37,6 +37,8 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>FlutterDeepLinkingEnabled</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
## Summary
- Disable Flutter built-in native deep-link routing on Android and iOS so invite links are handled only by the existing app_links invite flow.
- Preserve the existing web invite URL shape and association files.

Closes #81

## Verification
- dart format: not run; no Dart files changed.
- flutter analyze: completed with existing info-level findings in untouched Dart/test files.
- flutter test test/widget_test.dart: passed, 12 tests.
- flutter build web: not run; web/deploy association files were not touched.