### PR TITLE
Add deploy process tests for #12

### DIFF
--- a/test/deploy_process_test.dart
+++ b/test/deploy_process_test.dart
@@ -1,0 +1,55 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('deploy workflow', () {
+    test('builds web and prepares Vercel deployment files', () {
+      final workflow = File(
+        '.github/workflows/deploy-web-to-vercel.yml',
+      ).readAsStringSync();
+
+      expect(workflow, contains('run: flutter pub get'));
+      expect(workflow, contains('run: flutter build web'));
+      expect(workflow, contains('cp vercel.json build/web/vercel.json'));
+      expect(workflow, contains('mkdir -p build/web/.well-known'));
+      expect(
+        workflow,
+        contains(
+          'cp web/.well-known/apple-app-site-association '
+          'build/web/.well-known/apple-app-site-association',
+        ),
+      );
+      expect(
+        workflow,
+        contains(
+          'cp web/.well-known/assetlinks.json '
+          'build/web/.well-known/assetlinks.json',
+        ),
+      );
+      expect(workflow, contains('vercel --cwd build/web deploy'));
+    });
+
+    test(
+      'Vercel routing files copied by deploy workflow exist and are valid',
+      () {
+        final deployFiles = <String>[
+          'vercel.json',
+          'web/.well-known/apple-app-site-association',
+          'web/.well-known/assetlinks.json',
+        ];
+
+        for (final path in deployFiles) {
+          final file = File(path);
+          expect(file.existsSync(), isTrue, reason: '$path must exist');
+          expect(
+            () => jsonDecode(file.readAsStringSync()),
+            returnsNormally,
+            reason: '$path must contain valid JSON',
+          );
+        }
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Adds Flutter tests for the deploy workflow assumptions: dependency install, web build, Vercel deploy cwd, and routing file copy commands.
- Verifies the source Vercel and well-known files exist and contain valid JSON.

Closes #12

## Verification
- `dart format test/deploy_process_test.dart` - passed
- `flutter pub get` - passed
- `flutter analyze` - completed with 60 pre-existing info-level issues in `lib/main.dart` and `test/widget_test.dart`
- `flutter test` - passed, 14 tests
- `flutter build web` - passed