### PR TITLE
Fix #83 level-end modal titles

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -53,7 +53,7 @@
   "enterEmailAndPassword": "أدخل البريد الإلكتروني وكلمة المرور",
   "enterEmailFirst": "أدخل بريدك الإلكتروني أولًا",
   "enterValidEmail": "أدخل بريدًا إلكترونيًا صالحًا",
-  "failedNodes": "فشل {nodeCount} عقد",
+  "failedNodes": "فشل الرسم البياني {nodeCount}",
   "@failedNodes": {
     "placeholders": {
       "nodeCount": {
@@ -128,7 +128,7 @@
   "signOut": "تسجيل الخروج",
   "signUp": "إنشاء حساب",
   "signUpToCompete": " للمنافسة مع أصدقائك",
-  "solvedNodes": "تم حل {nodeCount} عقد",
+  "solvedNodes": "تم حل الرسم البياني {nodeCount}",
   "@solvedNodes": {
     "placeholders": {
       "nodeCount": {

--- a/lib/l10n/app_bn.arb
+++ b/lib/l10n/app_bn.arb
@@ -53,7 +53,7 @@
   "enterEmailAndPassword": "ইমেইল এবং পাসওয়ার্ড লিখুন",
   "enterEmailFirst": "প্রথমে আপনার ইমেইল লিখুন",
   "enterValidEmail": "একটি বৈধ ইমেইল লিখুন",
-  "failedNodes": "{nodeCount} নোড ব্যর্থ",
+  "failedNodes": "গ্রাফ {nodeCount} ব্যর্থ",
   "@failedNodes": {
     "placeholders": {
       "nodeCount": {
@@ -128,7 +128,7 @@
   "signOut": "সাইন আউট",
   "signUp": "সাইন আপ",
   "signUpToCompete": " আপনার বন্ধুদের সাথে প্রতিযোগিতা করতে",
-  "solvedNodes": "{nodeCount} নোড সমাধান হয়েছে",
+  "solvedNodes": "গ্রাফ {nodeCount} সমাধান হয়েছে",
   "@solvedNodes": {
     "placeholders": {
       "nodeCount": {

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -53,7 +53,7 @@
   "enterEmailAndPassword": "Geben Sie E-Mail und Passwort ein",
   "enterEmailFirst": "Geben Sie zuerst Ihre E-Mail-Adresse ein",
   "enterValidEmail": "Geben Sie eine gültige E-Mail-Adresse ein",
-  "failedNodes": "{nodeCount} knoten fehlgeschlagen",
+  "failedNodes": "graph {nodeCount} fehlgeschlagen",
   "@failedNodes": {
     "placeholders": {
       "nodeCount": {
@@ -128,7 +128,7 @@
   "signOut": "abmelden",
   "signUp": "registrieren",
   "signUpToCompete": " um mit deinen Freunden zu konkurrieren",
-  "solvedNodes": "{nodeCount} knoten gelöst",
+  "solvedNodes": "graph {nodeCount} gelöst",
   "@solvedNodes": {
     "placeholders": {
       "nodeCount": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -53,7 +53,7 @@
   "enterEmailAndPassword": "enter email and password",
   "enterEmailFirst": "enter your email first",
   "enterValidEmail": "enter a valid email",
-  "failedNodes": "failed {nodeCount} nodes",
+  "failedNodes": "graph {nodeCount} failed",
   "@failedNodes": {
     "placeholders": {
       "nodeCount": {
@@ -128,7 +128,7 @@
   "signOut": "sign out",
   "signUp": "sign up",
   "signUpToCompete": " to compete with your friends",
-  "solvedNodes": "solved {nodeCount} nodes",
+  "solvedNodes": "graph {nodeCount} solved",
   "@solvedNodes": {
     "placeholders": {
       "nodeCount": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -53,7 +53,7 @@
   "enterEmailAndPassword": "ingresa correo y contraseña",
   "enterEmailFirst": "ingresa tu correo primero",
   "enterValidEmail": "ingresa un correo válido",
-  "failedNodes": "fallaste {nodeCount} nodos",
+  "failedNodes": "grafo {nodeCount} fallido",
   "@failedNodes": {
     "placeholders": {
       "nodeCount": {
@@ -128,7 +128,7 @@
   "signOut": "cerrar sesión",
   "signUp": "registrarse",
   "signUpToCompete": " para competir con tus amigos",
-  "solvedNodes": "resolviste {nodeCount} nodos",
+  "solvedNodes": "grafo {nodeCount} resuelto",
   "@solvedNodes": {
     "placeholders": {
       "nodeCount": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -53,7 +53,7 @@
   "enterEmailAndPassword": "entrez l'email et le mot de passe",
   "enterEmailFirst": "entrez d'abord votre email",
   "enterValidEmail": "entrez un email valide",
-  "failedNodes": "{nodeCount} nœuds échoués",
+  "failedNodes": "graphe {nodeCount} échoué",
   "@failedNodes": {
     "placeholders": {
       "nodeCount": {
@@ -128,7 +128,7 @@
   "signOut": "se déconnecter",
   "signUp": "s'inscrire",
   "signUpToCompete": " rivaliser avec tes amis",
-  "solvedNodes": "{nodeCount} nœuds résolus",
+  "solvedNodes": "graphe {nodeCount} résolu",
   "@solvedNodes": {
     "placeholders": {
       "nodeCount": {

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -53,7 +53,7 @@
   "enterEmailAndPassword": "ईमेल और पासवर्ड दर्ज करें",
   "enterEmailFirst": "पहले अपना ईमेल दर्ज करें",
   "enterValidEmail": "मान्य ईमेल दर्ज करें",
-  "failedNodes": "{nodeCount} नोड विफल",
+  "failedNodes": "ग्राफ {nodeCount} विफल",
   "@failedNodes": {
     "placeholders": {
       "nodeCount": {
@@ -128,7 +128,7 @@
   "signOut": "साइन आउट",
   "signUp": "साइन अप",
   "signUpToCompete": " अपने मित्रों से प्रतिस्पर्धा करने के लिए",
-  "solvedNodes": "{nodeCount} नोड हल किए",
+  "solvedNodes": "ग्राफ {nodeCount} हल हुआ",
   "@solvedNodes": {
     "placeholders": {
       "nodeCount": {

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -53,7 +53,7 @@
   "enterEmailAndPassword": "masukkan email dan kata sandi",
   "enterEmailFirst": "masukkan emailmu terlebih dahulu",
   "enterValidEmail": "masukkan email yang valid",
-  "failedNodes": "gagal {nodeCount} node",
+  "failedNodes": "graf {nodeCount} gagal",
   "@failedNodes": {
     "placeholders": {
       "nodeCount": {
@@ -128,7 +128,7 @@
   "signOut": "keluar",
   "signUp": "daftar",
   "signUpToCompete": " untuk bersaing dengan teman-temanmu",
-  "solvedNodes": "menyelesaikan {nodeCount} node",
+  "solvedNodes": "graf {nodeCount} selesai",
   "@solvedNodes": {
     "placeholders": {
       "nodeCount": {

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -53,7 +53,7 @@
   "enterEmailAndPassword": "inserisci email e password",
   "enterEmailFirst": "inserisci prima la tua email",
   "enterValidEmail": "inserisci una email valida",
-  "failedNodes": "falliti {nodeCount} nodi",
+  "failedNodes": "grafo {nodeCount} fallito",
   "@failedNodes": {
     "placeholders": {
       "nodeCount": {
@@ -128,7 +128,7 @@
   "signOut": "esci",
   "signUp": "registrati",
   "signUpToCompete": " per competere con i tuoi amici",
-  "solvedNodes": "risolti {nodeCount} nodi",
+  "solvedNodes": "grafo {nodeCount} risolto",
   "@solvedNodes": {
     "placeholders": {
       "nodeCount": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -53,7 +53,7 @@
   "enterEmailAndPassword": "あなたのメールアドレスとパスワードを入力してください",
   "enterEmailFirst": "最初にメールアドレスを入力してください",
   "enterValidEmail": "有効なメールアドレスを入力してください",
-  "failedNodes": "{nodeCount} ノード失敗",
+  "failedNodes": "グラフ {nodeCount} 失敗",
   "@failedNodes": {
     "placeholders": {
       "nodeCount": {
@@ -128,7 +128,7 @@
   "signOut": "ログアウト",
   "signUp": "登録",
   "signUpToCompete": " 友達と競い合うために",
-  "solvedNodes": "{nodeCount} ノード解決",
+  "solvedNodes": "グラフ {nodeCount} 解決",
   "@solvedNodes": {
     "placeholders": {
       "nodeCount": {

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -53,7 +53,7 @@
   "enterEmailAndPassword": "이메일과 비밀번호를 입력하세요",
   "enterEmailFirst": "먼저 이메일을 입력하세요",
   "enterValidEmail": "올바른 이메일을 입력해 주세요.",
-  "failedNodes": "{nodeCount}개 노드 실패",
+  "failedNodes": "그래프 {nodeCount} 실패",
   "@failedNodes": {
     "placeholders": {
       "nodeCount": {
@@ -128,7 +128,7 @@
   "signOut": "로그아웃",
   "signUp": "가입",
   "signUpToCompete": " 친구들과 경쟁하기 위해",
-  "solvedNodes": "{nodeCount}개 노드 해결",
+  "solvedNodes": "그래프 {nodeCount} 해결",
   "@solvedNodes": {
     "placeholders": {
       "nodeCount": {

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -53,7 +53,7 @@
   "enterEmailAndPassword": "Introduza o seu e-mail e palavra-passe",
   "enterEmailFirst": "introduza o seu e-mail primeiro",
   "enterValidEmail": "Digite um e-mail válido",
-  "failedNodes": "falhou {nodeCount} nós",
+  "failedNodes": "grafo {nodeCount} falhou",
   "@failedNodes": {
     "placeholders": {
       "nodeCount": {
@@ -128,7 +128,7 @@
   "signOut": "sair",
   "signUp": "cadastrar",
   "signUpToCompete": " para competir com os seus amigos",
-  "solvedNodes": "resolveu {nodeCount} nós",
+  "solvedNodes": "grafo {nodeCount} resolvido",
   "@solvedNodes": {
     "placeholders": {
       "nodeCount": {

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -53,7 +53,7 @@
   "enterEmailAndPassword": "введите адрес электронной почты и пароль",
   "enterEmailFirst": "сначала введите свой адрес электронной почты",
   "enterValidEmail": "введите действительный адрес электронной почты",
-  "failedNodes": "не удалось {nodeCount} узлов",
+  "failedNodes": "граф {nodeCount} не пройден",
   "@failedNodes": {
     "placeholders": {
       "nodeCount": {
@@ -128,7 +128,7 @@
   "signOut": "выйти",
   "signUp": "зарегистрироваться",
   "signUpToCompete": " соревноваться с друзьями",
-  "solvedNodes": "решено {nodeCount} узлов",
+  "solvedNodes": "граф {nodeCount} решен",
   "@solvedNodes": {
     "placeholders": {
       "nodeCount": {

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -53,7 +53,7 @@
   "enterEmailAndPassword": "Lütfen e-posta ve şifre girin.",
   "enterEmailFirst": "önce e - postanızı girin",
   "enterValidEmail": "Geçerli bir e-posta adresi girin",
-  "failedNodes": "{nodeCount} düğüm başarısız",
+  "failedNodes": "graf {nodeCount} başarısız",
   "@failedNodes": {
     "placeholders": {
       "nodeCount": {
@@ -128,7 +128,7 @@
   "signOut": "çıkış yap",
   "signUp": "kaydol",
   "signUpToCompete": " arkadaşlarınızla rekabet etmek için",
-  "solvedNodes": "{nodeCount} düğüm çözüldü",
+  "solvedNodes": "graf {nodeCount} çözüldü",
   "@solvedNodes": {
     "placeholders": {
       "nodeCount": {

--- a/lib/l10n/app_ur.arb
+++ b/lib/l10n/app_ur.arb
@@ -53,7 +53,7 @@
   "enterEmailAndPassword": "ای میل اور پاس ورڈ درج کریں",
   "enterEmailFirst": "پہلے اپنا ای میل درج کریں",
   "enterValidEmail": " مہربانی کریتھ کریو صحیح ای میل درج ۔",
-  "failedNodes": "{nodeCount} نوڈز ناکام ہوئے",
+  "failedNodes": "گراف {nodeCount} ناکام ہوا",
   "@failedNodes": {
     "placeholders": {
       "nodeCount": {
@@ -128,7 +128,7 @@
   "signOut": "سائن آؤٹ",
   "signUp": "سائن اپ",
   "signUpToCompete": " اپنے دوستوں کے ساتھ مقابلہ کرنے کے لیے",
-  "solvedNodes": "{nodeCount} نوڈز حل ہوئے",
+  "solvedNodes": "گراف {nodeCount} حل ہوا",
   "@solvedNodes": {
     "placeholders": {
       "nodeCount": {

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -53,7 +53,7 @@
   "enterEmailAndPassword": "nhập email và mật khẩu",
   "enterEmailFirst": "nhập email của bạn trước",
   "enterValidEmail": "nhập một email hợp lệ",
-  "failedNodes": "thất bại {nodeCount} nút",
+  "failedNodes": "đồ thị {nodeCount} thất bại",
   "@failedNodes": {
     "placeholders": {
       "nodeCount": {
@@ -128,7 +128,7 @@
   "signOut": "đăng xuất",
   "signUp": "đăng ký",
   "signUpToCompete": " để cạnh tranh với bạn bè của bạn",
-  "solvedNodes": "đã giải {nodeCount} nút",
+  "solvedNodes": "đồ thị {nodeCount} đã giải",
   "@solvedNodes": {
     "placeholders": {
       "nodeCount": {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -53,7 +53,7 @@
   "enterEmailAndPassword": "请输入邮箱和密码",
   "enterEmailFirst": "请先输入邮箱",
   "enterValidEmail": "请输入有效邮箱",
-  "failedNodes": "{nodeCount} 个节点失败",
+  "failedNodes": "图 {nodeCount} 失败",
   "@failedNodes": {
     "placeholders": {
       "nodeCount": {
@@ -128,7 +128,7 @@
   "signOut": "退出登录",
   "signUp": "注册",
   "signUpToCompete": " 来和好友竞争",
-  "solvedNodes": "已解决 {nodeCount} 个节点",
+  "solvedNodes": "图 {nodeCount} 已解决",
   "@solvedNodes": {
     "placeholders": {
       "nodeCount": {

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -323,7 +323,7 @@ abstract class AppLocalizations {
   /// No description provided for @failedNodes.
   ///
   /// In en, this message translates to:
-  /// **'failed {nodeCount} nodes'**
+  /// **'graph {nodeCount} failed'**
   String failedNodes(int nodeCount);
 
   /// No description provided for @friendInvite.
@@ -647,7 +647,7 @@ abstract class AppLocalizations {
   /// No description provided for @solvedNodes.
   ///
   /// In en, this message translates to:
-  /// **'solved {nodeCount} nodes'**
+  /// **'graph {nodeCount} solved'**
   String solvedNodes(int nodeCount);
 
   /// No description provided for @start.

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -117,7 +117,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String failedNodes(int nodeCount) {
-    return 'فشل $nodeCount عقد';
+    return 'فشل الرسم البياني $nodeCount';
   }
 
   @override
@@ -293,7 +293,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String solvedNodes(int nodeCount) {
-    return 'تم حل $nodeCount عقد';
+    return 'تم حل الرسم البياني $nodeCount';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_bn.dart
+++ b/lib/l10n/generated/app_localizations_bn.dart
@@ -115,7 +115,7 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String failedNodes(int nodeCount) {
-    return '$nodeCount নোড ব্যর্থ';
+    return 'গ্রাফ $nodeCount ব্যর্থ';
   }
 
   @override
@@ -294,7 +294,7 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String solvedNodes(int nodeCount) {
-    return '$nodeCount নোড সমাধান হয়েছে';
+    return 'গ্রাফ $nodeCount সমাধান হয়েছে';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -117,7 +117,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String failedNodes(int nodeCount) {
-    return '$nodeCount knoten fehlgeschlagen';
+    return 'graph $nodeCount fehlgeschlagen';
   }
 
   @override
@@ -302,7 +302,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String solvedNodes(int nodeCount) {
-    return '$nodeCount knoten gelöst';
+    return 'graph $nodeCount gelöst';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -116,7 +116,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String failedNodes(int nodeCount) {
-    return 'failed $nodeCount nodes';
+    return 'graph $nodeCount failed';
   }
 
   @override
@@ -294,7 +294,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String solvedNodes(int nodeCount) {
-    return 'solved $nodeCount nodes';
+    return 'graph $nodeCount solved';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -118,7 +118,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String failedNodes(int nodeCount) {
-    return 'fallaste $nodeCount nodos';
+    return 'grafo $nodeCount fallido';
   }
 
   @override
@@ -299,7 +299,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String solvedNodes(int nodeCount) {
-    return 'resolviste $nodeCount nodos';
+    return 'grafo $nodeCount resuelto';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -118,7 +118,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String failedNodes(int nodeCount) {
-    return '$nodeCount nœuds échoués';
+    return 'graphe $nodeCount échoué';
   }
 
   @override
@@ -302,7 +302,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String solvedNodes(int nodeCount) {
-    return '$nodeCount nœuds résolus';
+    return 'graphe $nodeCount résolu';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_hi.dart
+++ b/lib/l10n/generated/app_localizations_hi.dart
@@ -116,7 +116,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String failedNodes(int nodeCount) {
-    return '$nodeCount नोड विफल';
+    return 'ग्राफ $nodeCount विफल';
   }
 
   @override
@@ -295,7 +295,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String solvedNodes(int nodeCount) {
-    return '$nodeCount नोड हल किए';
+    return 'ग्राफ $nodeCount हल हुआ';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_id.dart
+++ b/lib/l10n/generated/app_localizations_id.dart
@@ -116,7 +116,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String failedNodes(int nodeCount) {
-    return 'gagal $nodeCount node';
+    return 'graf $nodeCount gagal';
   }
 
   @override
@@ -294,7 +294,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String solvedNodes(int nodeCount) {
-    return 'menyelesaikan $nodeCount node';
+    return 'graf $nodeCount selesai';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -118,7 +118,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String failedNodes(int nodeCount) {
-    return 'falliti $nodeCount nodi';
+    return 'grafo $nodeCount fallito';
   }
 
   @override
@@ -301,7 +301,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String solvedNodes(int nodeCount) {
-    return 'risolti $nodeCount nodi';
+    return 'grafo $nodeCount risolto';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -112,7 +112,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String failedNodes(int nodeCount) {
-    return '$nodeCount ノード失敗';
+    return 'グラフ $nodeCount 失敗';
   }
 
   @override
@@ -281,7 +281,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String solvedNodes(int nodeCount) {
-    return '$nodeCount ノード解決';
+    return 'グラフ $nodeCount 解決';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_ko.dart
+++ b/lib/l10n/generated/app_localizations_ko.dart
@@ -112,7 +112,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String failedNodes(int nodeCount) {
-    return '$nodeCount개 노드 실패';
+    return '그래프 $nodeCount 실패';
   }
 
   @override
@@ -282,7 +282,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String solvedNodes(int nodeCount) {
-    return '$nodeCount개 노드 해결';
+    return '그래프 $nodeCount 해결';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -116,7 +116,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String failedNodes(int nodeCount) {
-    return 'falhou $nodeCount nós';
+    return 'grafo $nodeCount falhou';
   }
 
   @override
@@ -299,7 +299,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String solvedNodes(int nodeCount) {
-    return 'resolveu $nodeCount nós';
+    return 'grafo $nodeCount resolvido';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -119,7 +119,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String failedNodes(int nodeCount) {
-    return 'не удалось $nodeCount узлов';
+    return 'граф $nodeCount не пройден';
   }
 
   @override
@@ -301,7 +301,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String solvedNodes(int nodeCount) {
-    return 'решено $nodeCount узлов';
+    return 'граф $nodeCount решен';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -118,7 +118,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String failedNodes(int nodeCount) {
-    return '$nodeCount düğüm başarısız';
+    return 'graf $nodeCount başarısız';
   }
 
   @override
@@ -300,7 +300,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String solvedNodes(int nodeCount) {
-    return '$nodeCount düğüm çözüldü';
+    return 'graf $nodeCount çözüldü';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_ur.dart
+++ b/lib/l10n/generated/app_localizations_ur.dart
@@ -116,7 +116,7 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String failedNodes(int nodeCount) {
-    return '$nodeCount نوڈز ناکام ہوئے';
+    return 'گراف $nodeCount ناکام ہوا';
   }
 
   @override
@@ -296,7 +296,7 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String solvedNodes(int nodeCount) {
-    return '$nodeCount نوڈز حل ہوئے';
+    return 'گراف $nodeCount حل ہوا';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_vi.dart
+++ b/lib/l10n/generated/app_localizations_vi.dart
@@ -117,7 +117,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String failedNodes(int nodeCount) {
-    return 'thất bại $nodeCount nút';
+    return 'đồ thị $nodeCount thất bại';
   }
 
   @override
@@ -298,7 +298,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String solvedNodes(int nodeCount) {
-    return 'đã giải $nodeCount nút';
+    return 'đồ thị $nodeCount đã giải';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -112,7 +112,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String failedNodes(int nodeCount) {
-    return '$nodeCount 个节点失败';
+    return '图 $nodeCount 失败';
   }
 
   @override
@@ -280,7 +280,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String solvedNodes(int nodeCount) {
-    return '已解决 $nodeCount 个节点';
+    return '图 $nodeCount 已解决';
   }
 
   @override

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,10 +1,10 @@
-import 'dart:ui';
 import 'dart:convert';
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:planarity/l10n/generated/app_localizations_en.dart';
 import 'package:planarity/main.dart';
 
 String _todayKey() {
@@ -32,6 +32,13 @@ void main() {
     expect(scoreForSolvedLevel(level: 6, movesUsed: 2), 4);
     expect(scoreForSolvedLevel(level: 6, movesUsed: 6), 0);
     expect(scoreForSolvedLevel(level: 6, movesUsed: 8), 0);
+  });
+
+  test('completion modal titles identify the graph result', () {
+    final l10n = AppLocalizationsEn();
+
+    expect(l10n.solvedNodes(8), 'graph 8 solved');
+    expect(l10n.failedNodes(8), 'graph 8 failed');
   });
 
   test('display name validation blocks unsafe personal info and profanity', () {


### PR DESCRIPTION
## Summary
- Updates level-end modal result titles from node-count wording to graph result wording across all ARB localizations.
- Regenerates Flutter localization Dart files.
- Adds a focused English localization test for solved and failed graph titles.

Closes #83

## Verification
- `dart format test/widget_test.dart lib/l10n/generated` passed; formatted 19 files, 0 changed.
- `flutter analyze` completed with 59 existing info-level issues in `lib/main.dart` (deprecated APIs and BuildContext async-gap lints); no errors from this change.
- `flutter test test/widget_test.dart` passed; 13 tests passed.