### PR TITLE
Fix #76: Update level subtitles

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -43,6 +43,17 @@
   "copyrightNateWolfe": "© nate wolfe",
   "createAccountSubtitle": "أنشئ حسابًا باستخدام بريدك الإلكتروني وكلمة المرور",
   "dailyGraphPuzzle": "لغز الرسم البياني اليومي",
+  "levelSubtitleUntangleMoves": "{moveCount, plural, one {فك الرسم البياني في حركة واحدة} two {فك الرسم البياني في حركتين} few {فك الرسم البياني في {moveCount} حركات} many {فك الرسم البياني في {moveCount} حركة} other {فك الرسم البياني في {moveCount} حركة}}",
+  "@levelSubtitleUntangleMoves": {
+    "placeholders": {
+      "moveCount": {
+        "type": "int"
+      }
+    }
+  },
+  "levelSubtitleNoCrossings": "تخلص من كل التقاطعات",
+  "levelSubtitleKeepStreak": "واصل السلسلة",
+  "levelSubtitlePerfectSolve": "اسع إلى حل مثالي",
   "dailyScore": "نتيجة اليوم",
   "decline": "رفض",
   "deleteAccount": "حذف الحساب",

--- a/lib/l10n/app_bn.arb
+++ b/lib/l10n/app_bn.arb
@@ -43,6 +43,17 @@
   "copyrightNateWolfe": "© nate wolfe",
   "createAccountSubtitle": "আপনার ইমেল এবং পাসওয়ার্ড দিয়ে একটি অ্যাকাউন্ট তৈরি করুন।",
   "dailyGraphPuzzle": "দৈনিক গ্রাফ ধাঁধা",
+  "levelSubtitleUntangleMoves": "{moveCount} চালে গ্রাফটি খুলুন",
+  "@levelSubtitleUntangleMoves": {
+    "placeholders": {
+      "moveCount": {
+        "type": "int"
+      }
+    }
+  },
+  "levelSubtitleNoCrossings": "সব ক্রসিং সরিয়ে দিন",
+  "levelSubtitleKeepStreak": "ধারাবাহিকতা চালিয়ে যান",
+  "levelSubtitlePerfectSolve": "নিখুঁত সমাধানের চেষ্টা করুন",
   "dailyScore": "দৈনিক স্কোর",
   "decline": "হ্রাস",
   "deleteAccount": "অ্যাকাউন্ট মুছুন",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -43,6 +43,17 @@
   "copyrightNateWolfe": "© nate wolfe",
   "createAccountSubtitle": "Erstellen Sie ein Konto mit Ihrer E-Mail-Adresse und Ihrem Passwort.",
   "dailyGraphPuzzle": "tägliches graphenrätsel",
+  "levelSubtitleUntangleMoves": "entwirre den graphen in {moveCount} zügen",
+  "@levelSubtitleUntangleMoves": {
+    "placeholders": {
+      "moveCount": {
+        "type": "int"
+      }
+    }
+  },
+  "levelSubtitleNoCrossings": "entferne alle kreuzungen",
+  "levelSubtitleKeepStreak": "halte die serie am laufen",
+  "levelSubtitlePerfectSolve": "jage eine perfekte lösung",
   "dailyScore": "tagesscore",
   "decline": "Abfall",
   "deleteAccount": "konto löschen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -43,6 +43,17 @@
   "copyrightNateWolfe": "© nate wolfe",
   "createAccountSubtitle": "create an account with your email and password.",
   "dailyGraphPuzzle": "daily graph puzzle",
+  "levelSubtitleUntangleMoves": "{moveCount, plural, one {untangle the graph in 1 move} other {untangle the graph in {moveCount} moves}}",
+  "@levelSubtitleUntangleMoves": {
+    "placeholders": {
+      "moveCount": {
+        "type": "int"
+      }
+    }
+  },
+  "levelSubtitleNoCrossings": "get rid of all the crossings",
+  "levelSubtitleKeepStreak": "keep the streak going",
+  "levelSubtitlePerfectSolve": "chase a perfect solve",
   "dailyScore": "daily score",
   "decline": "decline",
   "deleteAccount": "delete account",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -43,6 +43,17 @@
   "copyrightNateWolfe": "© nate wolfe",
   "createAccountSubtitle": "crea una cuenta con tu correo y contraseña",
   "dailyGraphPuzzle": "rompecabezas diario de grafos",
+  "levelSubtitleUntangleMoves": "desenreda el grafo en {moveCount} movimientos",
+  "@levelSubtitleUntangleMoves": {
+    "placeholders": {
+      "moveCount": {
+        "type": "int"
+      }
+    }
+  },
+  "levelSubtitleNoCrossings": "elimina todos los cruces",
+  "levelSubtitleKeepStreak": "mantén la racha",
+  "levelSubtitlePerfectSolve": "busca una solución perfecta",
   "dailyScore": "puntuación diaria",
   "decline": "rechazar",
   "deleteAccount": "eliminar cuenta",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -43,6 +43,17 @@
   "copyrightNateWolfe": "© nate wolfe",
   "createAccountSubtitle": "créez un compte avec votre email et votre mot de passe.",
   "dailyGraphPuzzle": "casse-tête graphique quotidien",
+  "levelSubtitleUntangleMoves": "démêle le graphe en {moveCount} coups",
+  "@levelSubtitleUntangleMoves": {
+    "placeholders": {
+      "moveCount": {
+        "type": "int"
+      }
+    }
+  },
+  "levelSubtitleNoCrossings": "supprime tous les croisements",
+  "levelSubtitleKeepStreak": "continue sur ta lancée",
+  "levelSubtitlePerfectSolve": "vise une résolution parfaite",
   "dailyScore": "score du jour",
   "decline": "déclin",
   "deleteAccount": "supprimer le compte",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -43,6 +43,17 @@
   "copyrightNateWolfe": "© nate wolfe",
   "createAccountSubtitle": "अपने ईमेल और पासवर्ड से खाता बनाएँ",
   "dailyGraphPuzzle": "दैनिक ग्राफ पहेली",
+  "levelSubtitleUntangleMoves": "ग्राफ को {moveCount} चालों में सुलझाएँ",
+  "@levelSubtitleUntangleMoves": {
+    "placeholders": {
+      "moveCount": {
+        "type": "int"
+      }
+    }
+  },
+  "levelSubtitleNoCrossings": "सभी क्रॉसिंग हटाएँ",
+  "levelSubtitleKeepStreak": "श्रृंखला जारी रखें",
+  "levelSubtitlePerfectSolve": "एक परफ़ेक्ट हल की कोशिश करें",
   "dailyScore": "दैनिक स्कोर",
   "decline": "अस्वीकार करें",
   "deleteAccount": "खाता हटाएँ",

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -43,6 +43,17 @@
   "copyrightNateWolfe": "© nate wolfe",
   "createAccountSubtitle": "buat akun dengan email dan kata sandi Anda.",
   "dailyGraphPuzzle": "teka-teki graf harian",
+  "levelSubtitleUntangleMoves": "urai graf dalam {moveCount} langkah",
+  "@levelSubtitleUntangleMoves": {
+    "placeholders": {
+      "moveCount": {
+        "type": "int"
+      }
+    }
+  },
+  "levelSubtitleNoCrossings": "hilangkan semua persilangan",
+  "levelSubtitleKeepStreak": "pertahankan rentetannya",
+  "levelSubtitlePerfectSolve": "kejar penyelesaian sempurna",
   "dailyScore": "skor harian",
   "decline": "menolak",
   "deleteAccount": "hapus akun",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -43,6 +43,17 @@
   "copyrightNateWolfe": "© nate wolfe",
   "createAccountSubtitle": "crea un account con la tua email e password.",
   "dailyGraphPuzzle": "rompicapo grafico quotidiano",
+  "levelSubtitleUntangleMoves": "districa il grafo in {moveCount} mosse",
+  "@levelSubtitleUntangleMoves": {
+    "placeholders": {
+      "moveCount": {
+        "type": "int"
+      }
+    }
+  },
+  "levelSubtitleNoCrossings": "elimina tutti gli incroci",
+  "levelSubtitleKeepStreak": "continua la serie",
+  "levelSubtitlePerfectSolve": "punta a una soluzione perfetta",
   "dailyScore": "punteggio giornaliero",
   "decline": "declino",
   "deleteAccount": "elimina account",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -43,6 +43,17 @@
   "copyrightNateWolfe": "© nate wolfe",
   "createAccountSubtitle": "メールアドレスとパスワードでアカウントを作成します。",
   "dailyGraphPuzzle": "デイリーグラフパズル",
+  "levelSubtitleUntangleMoves": "{moveCount}手でグラフをほどこう",
+  "@levelSubtitleUntangleMoves": {
+    "placeholders": {
+      "moveCount": {
+        "type": "int"
+      }
+    }
+  },
+  "levelSubtitleNoCrossings": "すべての交差をなくそう",
+  "levelSubtitleKeepStreak": "連勝を続けよう",
+  "levelSubtitlePerfectSolve": "完璧な解法を狙おう",
   "dailyScore": "デイリースコア",
   "decline": "",
   "deleteAccount": "アカウントを削除",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -43,6 +43,17 @@
   "copyrightNateWolfe": "© nate wolfe",
   "createAccountSubtitle": "이메일과 비밀번호로 계정을 만드세요.",
   "dailyGraphPuzzle": "일일 그래프 퍼즐",
+  "levelSubtitleUntangleMoves": "{moveCount}번 안에 그래프를 풀어보세요",
+  "@levelSubtitleUntangleMoves": {
+    "placeholders": {
+      "moveCount": {
+        "type": "int"
+      }
+    }
+  },
+  "levelSubtitleNoCrossings": "모든 교차를 없애세요",
+  "levelSubtitleKeepStreak": "연속 기록을 이어가세요",
+  "levelSubtitlePerfectSolve": "완벽한 풀이에 도전하세요",
   "dailyScore": "일일 점수",
   "decline": "거부",
   "deleteAccount": "계정 삭제",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -20,3 +20,18 @@ extension AppLocalizationsReportReason on AppLocalizations {
     };
   }
 }
+
+extension AppLocalizationsLevelSubtitle on AppLocalizations {
+  String levelSubtitle({required int score, required int moveCount}) {
+    if (score >= 30) {
+      return levelSubtitlePerfectSolve;
+    }
+    if (score >= 15) {
+      return levelSubtitleKeepStreak;
+    }
+    if (score >= 5) {
+      return levelSubtitleNoCrossings;
+    }
+    return levelSubtitleUntangleMoves(moveCount);
+  }
+}

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -43,6 +43,17 @@
   "copyrightNateWolfe": "© nate wolfe",
   "createAccountSubtitle": "crie uma conta com o seu e-mail e palavra-passe.",
   "dailyGraphPuzzle": "quebra-cabeça diário de grafos",
+  "levelSubtitleUntangleMoves": "desembarace o grafo em {moveCount} movimentos",
+  "@levelSubtitleUntangleMoves": {
+    "placeholders": {
+      "moveCount": {
+        "type": "int"
+      }
+    }
+  },
+  "levelSubtitleNoCrossings": "elimine todos os cruzamentos",
+  "levelSubtitleKeepStreak": "mantenha a sequência",
+  "levelSubtitlePerfectSolve": "busque uma solução perfeita",
   "dailyScore": "pontuação diária",
   "decline": "declínio",
   "deleteAccount": "excluir conta",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -43,6 +43,17 @@
   "copyrightNateWolfe": "© nate wolfe",
   "createAccountSubtitle": "создайте учетную запись с вашим адресом электронной почты и паролем.",
   "dailyGraphPuzzle": "ежедневная головоломка с графами",
+  "levelSubtitleUntangleMoves": "распутайте граф за {moveCount} ходов",
+  "@levelSubtitleUntangleMoves": {
+    "placeholders": {
+      "moveCount": {
+        "type": "int"
+      }
+    }
+  },
+  "levelSubtitleNoCrossings": "уберите все пересечения",
+  "levelSubtitleKeepStreak": "продолжайте серию",
+  "levelSubtitlePerfectSolve": "стремитесь к идеальному решению",
   "dailyScore": "дневной счет",
   "decline": "отклонить",
   "deleteAccount": "удалить аккаунт",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -43,6 +43,17 @@
   "copyrightNateWolfe": "© nate wolfe",
   "createAccountSubtitle": "e - posta adresiniz ve şifrenizle bir hesap oluşturun.",
   "dailyGraphPuzzle": "günlük grafik bulmacası",
+  "levelSubtitleUntangleMoves": "grafı {moveCount} hamlede çöz",
+  "@levelSubtitleUntangleMoves": {
+    "placeholders": {
+      "moveCount": {
+        "type": "int"
+      }
+    }
+  },
+  "levelSubtitleNoCrossings": "tüm kesişimleri kaldır",
+  "levelSubtitleKeepStreak": "seriyi sürdür",
+  "levelSubtitlePerfectSolve": "mükemmel çözümü kovala",
   "dailyScore": "günlük skor",
   "decline": "reddetmek",
   "deleteAccount": "hesabı sil",

--- a/lib/l10n/app_ur.arb
+++ b/lib/l10n/app_ur.arb
@@ -43,6 +43,17 @@
   "copyrightNateWolfe": "© nate wolfe",
   "createAccountSubtitle": "اپنے ای میل اور پاس ورڈ کے ساتھ ایک اکاؤنٹ بنائیں ۔",
   "dailyGraphPuzzle": "روزانہ گراف پہیلی",
+  "levelSubtitleUntangleMoves": "گراف کو {moveCount} چالوں میں سلجھائیں",
+  "@levelSubtitleUntangleMoves": {
+    "placeholders": {
+      "moveCount": {
+        "type": "int"
+      }
+    }
+  },
+  "levelSubtitleNoCrossings": "تمام کراسنگ ختم کریں",
+  "levelSubtitleKeepStreak": "سلسلہ جاری رکھیں",
+  "levelSubtitlePerfectSolve": "بہترین حل کی کوشش کریں",
   "dailyScore": "روزانہ اسکور",
   "decline": "مسترد کرنا",
   "deleteAccount": "اکاؤنٹ حذف کریں",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -43,6 +43,17 @@
   "copyrightNateWolfe": "© nate wolfe",
   "createAccountSubtitle": "tạo một tài khoản với email và mật khẩu của bạn.",
   "dailyGraphPuzzle": "câu đố đồ thị hằng ngày",
+  "levelSubtitleUntangleMoves": "gỡ đồ thị trong {moveCount} nước đi",
+  "@levelSubtitleUntangleMoves": {
+    "placeholders": {
+      "moveCount": {
+        "type": "int"
+      }
+    }
+  },
+  "levelSubtitleNoCrossings": "loại bỏ mọi giao cắt",
+  "levelSubtitleKeepStreak": "giữ chuỗi tiếp tục",
+  "levelSubtitlePerfectSolve": "nhắm đến lời giải hoàn hảo",
   "dailyScore": "điểm hằng ngày",
   "decline": "sự suy sụp",
   "deleteAccount": "xóa tài khoản",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -43,6 +43,17 @@
   "copyrightNateWolfe": "© nate wolfe",
   "createAccountSubtitle": "使用邮箱和密码创建账户",
   "dailyGraphPuzzle": "每日图形谜题",
+  "levelSubtitleUntangleMoves": "在 {moveCount} 步内解开图形",
+  "@levelSubtitleUntangleMoves": {
+    "placeholders": {
+      "moveCount": {
+        "type": "int"
+      }
+    }
+  },
+  "levelSubtitleNoCrossings": "消除所有交叉",
+  "levelSubtitleKeepStreak": "延续连胜",
+  "levelSubtitlePerfectSolve": "追求完美解法",
   "dailyScore": "每日得分",
   "decline": "拒绝",
   "deleteAccount": "删除账户",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -260,6 +260,30 @@ abstract class AppLocalizations {
   /// **'daily graph puzzle'**
   String get dailyGraphPuzzle;
 
+  /// No description provided for @levelSubtitleUntangleMoves.
+  ///
+  /// In en, this message translates to:
+  /// **'{moveCount, plural, one {untangle the graph in 1 move} other {untangle the graph in {moveCount} moves}}'**
+  String levelSubtitleUntangleMoves(int moveCount);
+
+  /// No description provided for @levelSubtitleNoCrossings.
+  ///
+  /// In en, this message translates to:
+  /// **'get rid of all the crossings'**
+  String get levelSubtitleNoCrossings;
+
+  /// No description provided for @levelSubtitleKeepStreak.
+  ///
+  /// In en, this message translates to:
+  /// **'keep the streak going'**
+  String get levelSubtitleKeepStreak;
+
+  /// No description provided for @levelSubtitlePerfectSolve.
+  ///
+  /// In en, this message translates to:
+  /// **'chase a perfect solve'**
+  String get levelSubtitlePerfectSolve;
+
   /// No description provided for @dailyScore.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -86,6 +86,29 @@ class AppLocalizationsAr extends AppLocalizations {
   String get dailyGraphPuzzle => 'لغز الرسم البياني اليومي';
 
   @override
+  String levelSubtitleUntangleMoves(int moveCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      moveCount,
+      locale: localeName,
+      other: 'فك الرسم البياني في $moveCount حركة',
+      many: 'فك الرسم البياني في $moveCount حركة',
+      few: 'فك الرسم البياني في $moveCount حركات',
+      two: 'فك الرسم البياني في حركتين',
+      one: 'فك الرسم البياني في حركة واحدة',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get levelSubtitleNoCrossings => 'تخلص من كل التقاطعات';
+
+  @override
+  String get levelSubtitleKeepStreak => 'واصل السلسلة';
+
+  @override
+  String get levelSubtitlePerfectSolve => 'اسع إلى حل مثالي';
+
+  @override
   String get dailyScore => 'نتيجة اليوم';
 
   @override

--- a/lib/l10n/generated/app_localizations_bn.dart
+++ b/lib/l10n/generated/app_localizations_bn.dart
@@ -84,6 +84,20 @@ class AppLocalizationsBn extends AppLocalizations {
   String get dailyGraphPuzzle => 'দৈনিক গ্রাফ ধাঁধা';
 
   @override
+  String levelSubtitleUntangleMoves(int moveCount) {
+    return '$moveCount চালে গ্রাফটি খুলুন';
+  }
+
+  @override
+  String get levelSubtitleNoCrossings => 'সব ক্রসিং সরিয়ে দিন';
+
+  @override
+  String get levelSubtitleKeepStreak => 'ধারাবাহিকতা চালিয়ে যান';
+
+  @override
+  String get levelSubtitlePerfectSolve => 'নিখুঁত সমাধানের চেষ্টা করুন';
+
+  @override
   String get dailyScore => 'দৈনিক স্কোর';
 
   @override

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -86,6 +86,20 @@ class AppLocalizationsDe extends AppLocalizations {
   String get dailyGraphPuzzle => 'tägliches graphenrätsel';
 
   @override
+  String levelSubtitleUntangleMoves(int moveCount) {
+    return 'entwirre den graphen in $moveCount zügen';
+  }
+
+  @override
+  String get levelSubtitleNoCrossings => 'entferne alle kreuzungen';
+
+  @override
+  String get levelSubtitleKeepStreak => 'halte die serie am laufen';
+
+  @override
+  String get levelSubtitlePerfectSolve => 'jage eine perfekte lösung';
+
+  @override
   String get dailyScore => 'tagesscore';
 
   @override

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -85,6 +85,26 @@ class AppLocalizationsEn extends AppLocalizations {
   String get dailyGraphPuzzle => 'daily graph puzzle';
 
   @override
+  String levelSubtitleUntangleMoves(int moveCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      moveCount,
+      locale: localeName,
+      other: 'untangle the graph in $moveCount moves',
+      one: 'untangle the graph in 1 move',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get levelSubtitleNoCrossings => 'get rid of all the crossings';
+
+  @override
+  String get levelSubtitleKeepStreak => 'keep the streak going';
+
+  @override
+  String get levelSubtitlePerfectSolve => 'chase a perfect solve';
+
+  @override
   String get dailyScore => 'daily score';
 
   @override

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -86,6 +86,20 @@ class AppLocalizationsEs extends AppLocalizations {
   String get dailyGraphPuzzle => 'rompecabezas diario de grafos';
 
   @override
+  String levelSubtitleUntangleMoves(int moveCount) {
+    return 'desenreda el grafo en $moveCount movimientos';
+  }
+
+  @override
+  String get levelSubtitleNoCrossings => 'elimina todos los cruces';
+
+  @override
+  String get levelSubtitleKeepStreak => 'mantén la racha';
+
+  @override
+  String get levelSubtitlePerfectSolve => 'busca una solución perfecta';
+
+  @override
   String get dailyScore => 'puntuación diaria';
 
   @override

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -86,6 +86,20 @@ class AppLocalizationsFr extends AppLocalizations {
   String get dailyGraphPuzzle => 'casse-tête graphique quotidien';
 
   @override
+  String levelSubtitleUntangleMoves(int moveCount) {
+    return 'démêle le graphe en $moveCount coups';
+  }
+
+  @override
+  String get levelSubtitleNoCrossings => 'supprime tous les croisements';
+
+  @override
+  String get levelSubtitleKeepStreak => 'continue sur ta lancée';
+
+  @override
+  String get levelSubtitlePerfectSolve => 'vise une résolution parfaite';
+
+  @override
   String get dailyScore => 'score du jour';
 
   @override

--- a/lib/l10n/generated/app_localizations_hi.dart
+++ b/lib/l10n/generated/app_localizations_hi.dart
@@ -85,6 +85,20 @@ class AppLocalizationsHi extends AppLocalizations {
   String get dailyGraphPuzzle => 'दैनिक ग्राफ पहेली';
 
   @override
+  String levelSubtitleUntangleMoves(int moveCount) {
+    return 'ग्राफ को $moveCount चालों में सुलझाएँ';
+  }
+
+  @override
+  String get levelSubtitleNoCrossings => 'सभी क्रॉसिंग हटाएँ';
+
+  @override
+  String get levelSubtitleKeepStreak => 'श्रृंखला जारी रखें';
+
+  @override
+  String get levelSubtitlePerfectSolve => 'एक परफ़ेक्ट हल की कोशिश करें';
+
+  @override
   String get dailyScore => 'दैनिक स्कोर';
 
   @override

--- a/lib/l10n/generated/app_localizations_id.dart
+++ b/lib/l10n/generated/app_localizations_id.dart
@@ -85,6 +85,20 @@ class AppLocalizationsId extends AppLocalizations {
   String get dailyGraphPuzzle => 'teka-teki graf harian';
 
   @override
+  String levelSubtitleUntangleMoves(int moveCount) {
+    return 'urai graf dalam $moveCount langkah';
+  }
+
+  @override
+  String get levelSubtitleNoCrossings => 'hilangkan semua persilangan';
+
+  @override
+  String get levelSubtitleKeepStreak => 'pertahankan rentetannya';
+
+  @override
+  String get levelSubtitlePerfectSolve => 'kejar penyelesaian sempurna';
+
+  @override
   String get dailyScore => 'skor harian';
 
   @override

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -86,6 +86,20 @@ class AppLocalizationsIt extends AppLocalizations {
   String get dailyGraphPuzzle => 'rompicapo grafico quotidiano';
 
   @override
+  String levelSubtitleUntangleMoves(int moveCount) {
+    return 'districa il grafo in $moveCount mosse';
+  }
+
+  @override
+  String get levelSubtitleNoCrossings => 'elimina tutti gli incroci';
+
+  @override
+  String get levelSubtitleKeepStreak => 'continua la serie';
+
+  @override
+  String get levelSubtitlePerfectSolve => 'punta a una soluzione perfetta';
+
+  @override
   String get dailyScore => 'punteggio giornaliero';
 
   @override

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -81,6 +81,20 @@ class AppLocalizationsJa extends AppLocalizations {
   String get dailyGraphPuzzle => 'デイリーグラフパズル';
 
   @override
+  String levelSubtitleUntangleMoves(int moveCount) {
+    return '$moveCount手でグラフをほどこう';
+  }
+
+  @override
+  String get levelSubtitleNoCrossings => 'すべての交差をなくそう';
+
+  @override
+  String get levelSubtitleKeepStreak => '連勝を続けよう';
+
+  @override
+  String get levelSubtitlePerfectSolve => '完璧な解法を狙おう';
+
+  @override
   String get dailyScore => 'デイリースコア';
 
   @override

--- a/lib/l10n/generated/app_localizations_ko.dart
+++ b/lib/l10n/generated/app_localizations_ko.dart
@@ -81,6 +81,20 @@ class AppLocalizationsKo extends AppLocalizations {
   String get dailyGraphPuzzle => '일일 그래프 퍼즐';
 
   @override
+  String levelSubtitleUntangleMoves(int moveCount) {
+    return '$moveCount번 안에 그래프를 풀어보세요';
+  }
+
+  @override
+  String get levelSubtitleNoCrossings => '모든 교차를 없애세요';
+
+  @override
+  String get levelSubtitleKeepStreak => '연속 기록을 이어가세요';
+
+  @override
+  String get levelSubtitlePerfectSolve => '완벽한 풀이에 도전하세요';
+
+  @override
   String get dailyScore => '일일 점수';
 
   @override

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -85,6 +85,20 @@ class AppLocalizationsPt extends AppLocalizations {
   String get dailyGraphPuzzle => 'quebra-cabeça diário de grafos';
 
   @override
+  String levelSubtitleUntangleMoves(int moveCount) {
+    return 'desembarace o grafo em $moveCount movimentos';
+  }
+
+  @override
+  String get levelSubtitleNoCrossings => 'elimine todos os cruzamentos';
+
+  @override
+  String get levelSubtitleKeepStreak => 'mantenha a sequência';
+
+  @override
+  String get levelSubtitlePerfectSolve => 'busque uma solução perfeita';
+
+  @override
   String get dailyScore => 'pontuação diária';
 
   @override

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -85,6 +85,20 @@ class AppLocalizationsRu extends AppLocalizations {
   String get dailyGraphPuzzle => 'ежедневная головоломка с графами';
 
   @override
+  String levelSubtitleUntangleMoves(int moveCount) {
+    return 'распутайте граф за $moveCount ходов';
+  }
+
+  @override
+  String get levelSubtitleNoCrossings => 'уберите все пересечения';
+
+  @override
+  String get levelSubtitleKeepStreak => 'продолжайте серию';
+
+  @override
+  String get levelSubtitlePerfectSolve => 'стремитесь к идеальному решению';
+
+  @override
   String get dailyScore => 'дневной счет';
 
   @override

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -86,6 +86,20 @@ class AppLocalizationsTr extends AppLocalizations {
   String get dailyGraphPuzzle => 'günlük grafik bulmacası';
 
   @override
+  String levelSubtitleUntangleMoves(int moveCount) {
+    return 'grafı $moveCount hamlede çöz';
+  }
+
+  @override
+  String get levelSubtitleNoCrossings => 'tüm kesişimleri kaldır';
+
+  @override
+  String get levelSubtitleKeepStreak => 'seriyi sürdür';
+
+  @override
+  String get levelSubtitlePerfectSolve => 'mükemmel çözümü kovala';
+
+  @override
   String get dailyScore => 'günlük skor';
 
   @override

--- a/lib/l10n/generated/app_localizations_ur.dart
+++ b/lib/l10n/generated/app_localizations_ur.dart
@@ -85,6 +85,20 @@ class AppLocalizationsUr extends AppLocalizations {
   String get dailyGraphPuzzle => 'روزانہ گراف پہیلی';
 
   @override
+  String levelSubtitleUntangleMoves(int moveCount) {
+    return 'گراف کو $moveCount چالوں میں سلجھائیں';
+  }
+
+  @override
+  String get levelSubtitleNoCrossings => 'تمام کراسنگ ختم کریں';
+
+  @override
+  String get levelSubtitleKeepStreak => 'سلسلہ جاری رکھیں';
+
+  @override
+  String get levelSubtitlePerfectSolve => 'بہترین حل کی کوشش کریں';
+
+  @override
   String get dailyScore => 'روزانہ اسکور';
 
   @override

--- a/lib/l10n/generated/app_localizations_vi.dart
+++ b/lib/l10n/generated/app_localizations_vi.dart
@@ -86,6 +86,20 @@ class AppLocalizationsVi extends AppLocalizations {
   String get dailyGraphPuzzle => 'câu đố đồ thị hằng ngày';
 
   @override
+  String levelSubtitleUntangleMoves(int moveCount) {
+    return 'gỡ đồ thị trong $moveCount nước đi';
+  }
+
+  @override
+  String get levelSubtitleNoCrossings => 'loại bỏ mọi giao cắt';
+
+  @override
+  String get levelSubtitleKeepStreak => 'giữ chuỗi tiếp tục';
+
+  @override
+  String get levelSubtitlePerfectSolve => 'nhắm đến lời giải hoàn hảo';
+
+  @override
   String get dailyScore => 'điểm hằng ngày';
 
   @override

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -81,6 +81,20 @@ class AppLocalizationsZh extends AppLocalizations {
   String get dailyGraphPuzzle => '每日图形谜题';
 
   @override
+  String levelSubtitleUntangleMoves(int moveCount) {
+    return '在 $moveCount 步内解开图形';
+  }
+
+  @override
+  String get levelSubtitleNoCrossings => '消除所有交叉';
+
+  @override
+  String get levelSubtitleKeepStreak => '延续连胜';
+
+  @override
+  String get levelSubtitlePerfectSolve => '追求完美解法';
+
+  @override
   String get dailyScore => '每日得分';
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5437,7 +5437,7 @@ class _PlanarityGamePageState extends State<PlanarityGamePage> {
               ),
               const SizedBox(height: 8),
               Text(
-                _l10n.dailyGraphPuzzle,
+                _l10n.levelSubtitle(score: _totalScore, moveCount: _level),
                 style: Theme.of(context).textTheme.bodyLarge?.copyWith(
                   color: Theme.of(
                     context,

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,10 +1,10 @@
-import 'dart:ui';
 import 'dart:convert';
 
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:planarity/l10n/app_localizations.dart';
 import 'package:planarity/main.dart';
 
 String _todayKey() {
@@ -307,6 +307,41 @@ void main() {
     expect(find.text('daily score'), findsOneWidget);
     expect(find.text('7'), findsOneWidget);
     expect(find.text('continue'), findsOneWidget);
+  });
+
+  testWidgets('Level page subtitle changes with current score', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) =>
+              Text(context.l10n.levelSubtitle(score: 0, moveCount: 6)),
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text('untangle the graph in 6 moves'), findsOneWidget);
+    expect(find.text('daily graph puzzle'), findsNothing);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) =>
+              Text(context.l10n.levelSubtitle(score: 30, moveCount: 6)),
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text('chase a perfect solve'), findsOneWidget);
   });
 
   testWidgets('Home page resets expired daily score to zero', (


### PR DESCRIPTION
## Summary
- Adds localized level subtitle messages that change by current score.
- Uses the score-based subtitle on level screens while keeping the home subtitle unchanged.
- Adds a focused widget test for low-score and high-score subtitle selection.

Closes #76

## Verification
- `dart format lib/main.dart lib/l10n/app_localizations.dart test/widget_test.dart` - passed
- `flutter gen-l10n` - passed
- `flutter analyze` - completed with existing info-level lints (59 issues, mostly deprecated APIs/use_build_context_synchronously)
- `flutter test test/widget_test.dart` - passed (13 tests)