### PR TITLE
Web | App Store Link (#80)

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -49,6 +49,7 @@
   "details": "التفاصيل",
   "detailsTooLong": "يجب أن تكون التفاصيل 1000 حرف أو أقل",
   "displayName": "اسم العرض",
+  "downloadOnAppStore": "تنزيل من App Store",
   "email": "البريد الإلكتروني",
   "enterEmailAndPassword": "أدخل البريد الإلكتروني وكلمة المرور",
   "enterEmailFirst": "أدخل بريدك الإلكتروني أولًا",

--- a/lib/l10n/app_bn.arb
+++ b/lib/l10n/app_bn.arb
@@ -49,6 +49,7 @@
   "details": "বিস্তারিত",
   "detailsTooLong": "বিবরণ 1000 অক্ষর বা তার কম হতে হবে",
   "displayName": "প্রদর্শনের নাম",
+  "downloadOnAppStore": "App Store থেকে ডাউনলোড করুন",
   "email": "ইমেল",
   "enterEmailAndPassword": "ইমেইল এবং পাসওয়ার্ড লিখুন",
   "enterEmailFirst": "প্রথমে আপনার ইমেইল লিখুন",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -49,6 +49,7 @@
   "details": "Details",
   "detailsTooLong": "Details dürfen maximal 1000 Zeichen lang sein",
   "displayName": "Anzeigename",
+  "downloadOnAppStore": "im App Store laden",
   "email": "e-mail",
   "enterEmailAndPassword": "Geben Sie E-Mail und Passwort ein",
   "enterEmailFirst": "Geben Sie zuerst Ihre E-Mail-Adresse ein",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -49,6 +49,7 @@
   "details": "details",
   "detailsTooLong": "details must be 1000 characters or less",
   "displayName": "display name",
+  "downloadOnAppStore": "download on the App Store",
   "email": "email",
   "enterEmailAndPassword": "enter email and password",
   "enterEmailFirst": "enter your email first",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -49,6 +49,7 @@
   "details": "detalles",
   "detailsTooLong": "los detalles deben tener 1000 caracteres o menos",
   "displayName": "nombre visible",
+  "downloadOnAppStore": "descargar en App Store",
   "email": "correo",
   "enterEmailAndPassword": "ingresa correo y contraseña",
   "enterEmailFirst": "ingresa tu correo primero",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -49,6 +49,7 @@
   "details": "détails",
   "detailsTooLong": "les détails doivent comporter 1 000 caractères ou moins",
   "displayName": "nom d'affichage",
+  "downloadOnAppStore": "télécharger sur l'App Store",
   "email": "e-mail",
   "enterEmailAndPassword": "entrez l'email et le mot de passe",
   "enterEmailFirst": "entrez d'abord votre email",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -49,6 +49,7 @@
   "details": "विवरण",
   "detailsTooLong": "विवरण 1000 अक्षर या कम होना चाहिए",
   "displayName": "प्रदर्शित नाम",
+  "downloadOnAppStore": "App Store से डाउनलोड करें",
   "email": "ईमेल",
   "enterEmailAndPassword": "ईमेल और पासवर्ड दर्ज करें",
   "enterEmailFirst": "पहले अपना ईमेल दर्ज करें",

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -49,6 +49,7 @@
   "details": "detail",
   "detailsTooLong": "detailnya harus 1000 karakter atau kurang",
   "displayName": "nama tampilan",
+  "downloadOnAppStore": "unduh di App Store",
   "email": "email",
   "enterEmailAndPassword": "masukkan email dan kata sandi",
   "enterEmailFirst": "masukkan emailmu terlebih dahulu",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -49,6 +49,7 @@
   "details": "dettagli",
   "detailsTooLong": "i dettagli devono contenere 1000 caratteri o meno",
   "displayName": "nome da visualizzare",
+  "downloadOnAppStore": "scarica su App Store",
   "email": "email",
   "enterEmailAndPassword": "inserisci email e password",
   "enterEmailFirst": "inserisci prima la tua email",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -49,6 +49,7 @@
   "details": "詳細",
   "detailsTooLong": "詳細は1000文字以内で入力してください",
   "displayName": "表示名",
+  "downloadOnAppStore": "App Storeでダウンロード",
   "email": "メール",
   "enterEmailAndPassword": "あなたのメールアドレスとパスワードを入力してください",
   "enterEmailFirst": "最初にメールアドレスを入力してください",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -49,6 +49,7 @@
   "details": "상세 정보",
   "detailsTooLong": "세부 정보는 1000자 이하여야 합니다",
   "displayName": "표시 이름",
+  "downloadOnAppStore": "App Store에서 다운로드",
   "email": "이메일",
   "enterEmailAndPassword": "이메일과 비밀번호를 입력하세요",
   "enterEmailFirst": "먼저 이메일을 입력하세요",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -49,6 +49,7 @@
   "details": "detalhes",
   "detailsTooLong": "os detalhes devem ter 1000 caracteres ou menos",
   "displayName": "Nome a apresentar",
+  "downloadOnAppStore": "baixar na App Store",
   "email": "email",
   "enterEmailAndPassword": "Introduza o seu e-mail e palavra-passe",
   "enterEmailFirst": "introduza o seu e-mail primeiro",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -49,6 +49,7 @@
   "details": "подробности",
   "detailsTooLong": "Подробности должны содержать не более 1000 символов.",
   "displayName": "отображаемое имя",
+  "downloadOnAppStore": "скачать в App Store",
   "email": "эл. почта",
   "enterEmailAndPassword": "введите адрес электронной почты и пароль",
   "enterEmailFirst": "сначала введите свой адрес электронной почты",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -49,6 +49,7 @@
   "details": "detaylar",
   "detailsTooLong": "ayrıntılar 1000 karakter veya daha kısa olmalıdır",
   "displayName": "görünen ad",
+  "downloadOnAppStore": "App Store'dan indir",
   "email": "e-posta",
   "enterEmailAndPassword": "Lütfen e-posta ve şifre girin.",
   "enterEmailFirst": "önce e - postanızı girin",

--- a/lib/l10n/app_ur.arb
+++ b/lib/l10n/app_ur.arb
@@ -49,6 +49,7 @@
   "details": "تفصیلات",
   "detailsTooLong": "تفصیلات 1000 حروف یا اس سے کم ہونی چاہئیں",
   "displayName": "ڈسپلے نام",
+  "downloadOnAppStore": "App Store سے ڈاؤن لوڈ کریں",
   "email": "ای میل",
   "enterEmailAndPassword": "ای میل اور پاس ورڈ درج کریں",
   "enterEmailFirst": "پہلے اپنا ای میل درج کریں",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -49,6 +49,7 @@
   "details": "chi tiết",
   "detailsTooLong": "chi tiết phải có 1000 ký tự trở xuống",
   "displayName": "tên hiển thị",
+  "downloadOnAppStore": "tải về trên App Store",
   "email": "email",
   "enterEmailAndPassword": "nhập email và mật khẩu",
   "enterEmailFirst": "nhập email của bạn trước",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -49,6 +49,7 @@
   "details": "详情",
   "detailsTooLong": "详情必须不超过 1000 个字符",
   "displayName": "显示名称",
+  "downloadOnAppStore": "在 App Store 下载",
   "email": "邮箱",
   "enterEmailAndPassword": "请输入邮箱和密码",
   "enterEmailFirst": "请先输入邮箱",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -296,6 +296,12 @@ abstract class AppLocalizations {
   /// **'display name'**
   String get displayName;
 
+  /// No description provided for @downloadOnAppStore.
+  ///
+  /// In en, this message translates to:
+  /// **'download on the App Store'**
+  String get downloadOnAppStore;
+
   /// No description provided for @email.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -104,6 +104,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get displayName => 'اسم العرض';
 
   @override
+  String get downloadOnAppStore => 'تنزيل من App Store';
+
+  @override
   String get email => 'البريد الإلكتروني';
 
   @override

--- a/lib/l10n/generated/app_localizations_bn.dart
+++ b/lib/l10n/generated/app_localizations_bn.dart
@@ -102,6 +102,9 @@ class AppLocalizationsBn extends AppLocalizations {
   String get displayName => 'প্রদর্শনের নাম';
 
   @override
+  String get downloadOnAppStore => 'App Store থেকে ডাউনলোড করুন';
+
+  @override
   String get email => 'ইমেল';
 
   @override

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -104,6 +104,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get displayName => 'Anzeigename';
 
   @override
+  String get downloadOnAppStore => 'im App Store laden';
+
+  @override
   String get email => 'e-mail';
 
   @override

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -103,6 +103,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get displayName => 'display name';
 
   @override
+  String get downloadOnAppStore => 'download on the App Store';
+
+  @override
   String get email => 'email';
 
   @override

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -105,6 +105,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get displayName => 'nombre visible';
 
   @override
+  String get downloadOnAppStore => 'descargar en App Store';
+
+  @override
   String get email => 'correo';
 
   @override

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -105,6 +105,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get displayName => 'nom d\'affichage';
 
   @override
+  String get downloadOnAppStore => 'télécharger sur l\'App Store';
+
+  @override
   String get email => 'e-mail';
 
   @override

--- a/lib/l10n/generated/app_localizations_hi.dart
+++ b/lib/l10n/generated/app_localizations_hi.dart
@@ -103,6 +103,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get displayName => 'प्रदर्शित नाम';
 
   @override
+  String get downloadOnAppStore => 'App Store से डाउनलोड करें';
+
+  @override
   String get email => 'ईमेल';
 
   @override

--- a/lib/l10n/generated/app_localizations_id.dart
+++ b/lib/l10n/generated/app_localizations_id.dart
@@ -103,6 +103,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get displayName => 'nama tampilan';
 
   @override
+  String get downloadOnAppStore => 'unduh di App Store';
+
+  @override
   String get email => 'email';
 
   @override

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -105,6 +105,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get displayName => 'nome da visualizzare';
 
   @override
+  String get downloadOnAppStore => 'scarica su App Store';
+
+  @override
   String get email => 'email';
 
   @override

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -99,6 +99,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get displayName => '表示名';
 
   @override
+  String get downloadOnAppStore => 'App Storeでダウンロード';
+
+  @override
   String get email => 'メール';
 
   @override

--- a/lib/l10n/generated/app_localizations_ko.dart
+++ b/lib/l10n/generated/app_localizations_ko.dart
@@ -99,6 +99,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get displayName => '표시 이름';
 
   @override
+  String get downloadOnAppStore => 'App Store에서 다운로드';
+
+  @override
   String get email => '이메일';
 
   @override

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -103,6 +103,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get displayName => 'Nome a apresentar';
 
   @override
+  String get downloadOnAppStore => 'baixar na App Store';
+
+  @override
   String get email => 'email';
 
   @override

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -104,6 +104,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get displayName => 'отображаемое имя';
 
   @override
+  String get downloadOnAppStore => 'скачать в App Store';
+
+  @override
   String get email => 'эл. почта';
 
   @override

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -105,6 +105,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get displayName => 'görünen ad';
 
   @override
+  String get downloadOnAppStore => 'App Store\'dan indir';
+
+  @override
   String get email => 'e-posta';
 
   @override

--- a/lib/l10n/generated/app_localizations_ur.dart
+++ b/lib/l10n/generated/app_localizations_ur.dart
@@ -103,6 +103,9 @@ class AppLocalizationsUr extends AppLocalizations {
   String get displayName => 'ڈسپلے نام';
 
   @override
+  String get downloadOnAppStore => 'App Store سے ڈاؤن لوڈ کریں';
+
+  @override
   String get email => 'ای میل';
 
   @override

--- a/lib/l10n/generated/app_localizations_vi.dart
+++ b/lib/l10n/generated/app_localizations_vi.dart
@@ -104,6 +104,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get displayName => 'tên hiển thị';
 
   @override
+  String get downloadOnAppStore => 'tải về trên App Store';
+
+  @override
   String get email => 'email';
 
   @override

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -99,6 +99,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get displayName => '显示名称';
 
   @override
+  String get downloadOnAppStore => '在 App Store 下载';
+
+  @override
   String get email => '邮箱';
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,6 +29,9 @@ bool _googleSignInReady = false;
 FirebaseAnalytics? _analytics;
 FirebaseAnalyticsObserver? _analyticsObserver;
 
+@visibleForTesting
+bool debugShowAppStoreDownloadButton = false;
+
 bool get _supportsMobileAds {
   if (kIsWeb) {
     return false;
@@ -279,6 +282,9 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
     'https://wxlfe.dev/?utm_source=planarity&utm_medium=app&utm_campaign=internal_referral&utm_content=footer_portfolio_link',
   );
   static final Uri _originalGameUri = Uri.parse('http://johntantalo.com/');
+  static final Uri _appStoreUri = Uri.parse(
+    'https://apps.apple.com/us/app/planarity-daily-graph-puzzle/id6762309242',
+  );
   static final Uri _planarGraphInfoUri = Uri.parse(
     'https://en.wikipedia.org/wiki/Planar_graph',
   );
@@ -2068,6 +2074,10 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
       scoreLabel: '$_score',
       isLocked: isLocked,
       onPlayPressed: _openChallenge,
+      showAppStoreDownloadButton: kIsWeb || debugShowAppStoreDownloadButton,
+      onAppStoreTap: () async {
+        await launchUrl(_appStoreUri, mode: LaunchMode.externalApplication);
+      },
       showLeaderboardBelowButton: !isWide,
       leaderboard: _LeaderboardCard(
         key: leaderboardKey,
@@ -2189,6 +2199,8 @@ class _HomeHeroContent extends StatelessWidget {
     required this.scoreLabel,
     required this.isLocked,
     required this.onPlayPressed,
+    required this.showAppStoreDownloadButton,
+    required this.onAppStoreTap,
     required this.showLeaderboardBelowButton,
     required this.leaderboard,
     required this.onPortfolioTap,
@@ -2199,6 +2211,8 @@ class _HomeHeroContent extends StatelessWidget {
   final String scoreLabel;
   final bool isLocked;
   final VoidCallback onPlayPressed;
+  final bool showAppStoreDownloadButton;
+  final VoidCallback onAppStoreTap;
   final bool showLeaderboardBelowButton;
   final Widget leaderboard;
   final VoidCallback onPortfolioTap;
@@ -2208,6 +2222,22 @@ class _HomeHeroContent extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = context.l10n;
+    final outlineButtonStyle = ButtonStyle(
+      side: WidgetStateProperty.resolveWith((states) {
+        if (states.contains(WidgetState.disabled)) {
+          return BorderSide(
+            color: theme.colorScheme.onSurface.withOpacity(0.3),
+          );
+        }
+        return BorderSide(color: theme.colorScheme.onSurface);
+      }),
+      foregroundColor: WidgetStateProperty.resolveWith((states) {
+        if (states.contains(WidgetState.disabled)) {
+          return theme.colorScheme.onSurface.withOpacity(0.3);
+        }
+        return theme.colorScheme.onSurface;
+      }),
+    );
     return LayoutBuilder(
       builder: (context, constraints) {
         final hasBoundedHeight = constraints.hasBoundedHeight;
@@ -2254,22 +2284,7 @@ class _HomeHeroContent extends StatelessWidget {
             const SizedBox(height: 21),
             OutlinedButton(
               onPressed: isLocked ? null : onPlayPressed,
-              style: ButtonStyle(
-                side: MaterialStateProperty.resolveWith((states) {
-                  if (states.contains(MaterialState.disabled)) {
-                    return BorderSide(
-                      color: theme.colorScheme.onSurface.withOpacity(0.3),
-                    );
-                  }
-                  return BorderSide(color: theme.colorScheme.onSurface);
-                }),
-                foregroundColor: MaterialStateProperty.resolveWith((states) {
-                  if (states.contains(MaterialState.disabled)) {
-                    return theme.colorScheme.onSurface.withOpacity(0.3);
-                  }
-                  return theme.colorScheme.onSurface;
-                }),
-              ),
+              style: outlineButtonStyle,
               child: Text(
                 buttonLabel,
                 style: theme.textTheme.bodyLarge?.copyWith(
@@ -2277,6 +2292,20 @@ class _HomeHeroContent extends StatelessWidget {
                 ),
               ),
             ),
+            if (showAppStoreDownloadButton) ...[
+              const SizedBox(height: 12),
+              OutlinedButton.icon(
+                onPressed: onAppStoreTap,
+                style: outlineButtonStyle,
+                icon: const FaIcon(FontAwesomeIcons.apple, size: 18),
+                label: Text(
+                  l10n.downloadOnAppStore,
+                  style: theme.textTheme.bodyLarge?.copyWith(
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ),
+            ],
             if (showLeaderboardBelowButton) ...[
               const SizedBox(height: 28),
               leaderboard,

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,4 +1,3 @@
-import 'dart:ui';
 import 'dart:convert';
 
 import 'package:flutter/widgets.dart';
@@ -123,6 +122,21 @@ void main() {
     expect(find.text('leaderboard'), findsOneWidget);
     expect(find.text('start'), findsOneWidget);
     expect(find.text('daily score'), findsOneWidget);
+  });
+
+  testWidgets('Web home page shows App Store download button', (
+    WidgetTester tester,
+  ) async {
+    debugShowAppStoreDownloadButton = true;
+    addTearDown(() {
+      debugShowAppStoreDownloadButton = false;
+    });
+
+    SharedPreferences.setMockInitialValues({});
+    await tester.pumpWidget(const PlanarityApp());
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text('download on the App Store'), findsOneWidget);
   });
 
   testWidgets('Home page follows a Spanish system locale', (


### PR DESCRIPTION
## Summary
- Adds a web-only App Store download button to the homepage hero.
- Launches the App Store URL with `LaunchMode.externalApplication` and localizes the new button label.
- Adds a focused widget test for the web homepage button path.

Closes #80

## Verification
- `dart format lib/main.dart test/widget_test.dart` - passed
- `flutter gen-l10n` - passed
- `flutter analyze` - completed with 55 existing info-level findings in `lib/main.dart` (`use_build_context_synchronously`, `deprecated_member_use`)
- `flutter test test/widget_test.dart` - passed
- `flutter build web` - passed