### PR TITLE
Add UMP consent gating for ads

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -111,6 +111,7 @@
   "passwordMinLength": "يجب أن تتكون كلمة المرور من 6 أحرف على الأقل",
   "passwordTooWeak": "كلمة المرور ضعيفة جدًا",
   "planarity": "planarity",
+  "privacyOptions": "خيارات الخصوصية",
   "planarGraphWikipedia": "ويكيبيديا: رسم بياني مستوٍ",
   "pressAgainToDelete": "اضغط مرة أخرى للحذف",
   "profile": "الملف الشخصي",

--- a/lib/l10n/app_bn.arb
+++ b/lib/l10n/app_bn.arb
@@ -111,6 +111,7 @@
   "passwordMinLength": "পাসওয়ার্ড কমপক্ষে 6 অক্ষরের হতে হবে",
   "passwordTooWeak": "পাসওয়ার্ড খুব দুর্বল",
   "planarity": "planarity",
+  "privacyOptions": "গোপনীয়তার বিকল্প",
   "planarGraphWikipedia": "উইকিপিডিয়া: প্ল্যানার গ্রাফ",
   "pressAgainToDelete": "মুছে ফেলার জন্য আবার টিপুন",
   "profile": "প্রোফাইল",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -111,6 +111,7 @@
   "passwordMinLength": "Das Passwort muss mindestens 6 Zeichen lang sein",
   "passwordTooWeak": "Passwort ist zu schwach",
   "planarity": "planarity",
+  "privacyOptions": "Datenschutzoptionen",
   "planarGraphWikipedia": "Wikipedia: Planarer Graph",
   "pressAgainToDelete": "Zum Löschen erneut drücken",
   "profile": "profil",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -111,6 +111,7 @@
   "passwordMinLength": "password must be at least 6 characters",
   "passwordTooWeak": "password is too weak",
   "planarity": "planarity",
+  "privacyOptions": "privacy options",
   "planarGraphWikipedia": "wikipedia: planar graph",
   "pressAgainToDelete": "press again to delete",
   "profile": "profile",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -111,6 +111,7 @@
   "passwordMinLength": "la contraseña debe tener al menos 6 caracteres",
   "passwordTooWeak": "la contraseña es demasiado débil",
   "planarity": "planarity",
+  "privacyOptions": "opciones de privacidad",
   "planarGraphWikipedia": "wikipedia: grafo planar",
   "pressAgainToDelete": "presiona de nuevo para eliminar",
   "profile": "perfil",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -111,6 +111,7 @@
   "passwordMinLength": "le mot de passe doit contenir au moins 6 caractères",
   "passwordTooWeak": "le mot de passe est trop faible",
   "planarity": "planarity",
+  "privacyOptions": "options de confidentialité",
   "planarGraphWikipedia": "wikipedia : graphe planaire",
   "pressAgainToDelete": "appuyez à nouveau pour supprimer",
   "profile": "profil",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -111,6 +111,7 @@
   "passwordMinLength": "पासवर्ड कम से कम 6 अक्षरों का होना चाहिए",
   "passwordTooWeak": "पासवर्ड बहुत कमजोर है",
   "planarity": "planarity",
+  "privacyOptions": "गोपनीयता विकल्प",
   "planarGraphWikipedia": "wikipedia: समतलीय ग्राफ",
   "pressAgainToDelete": "हटाने के लिए फिर दबाएँ",
   "profile": "प्रोफ़ाइल",

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -111,6 +111,7 @@
   "passwordMinLength": "kata sandi harus minimal 6 karakter",
   "passwordTooWeak": "kata sandi terlalu lemah",
   "planarity": "planarity",
+  "privacyOptions": "opsi privasi",
   "planarGraphWikipedia": "wikipedia: grafik planar",
   "pressAgainToDelete": "tekan lagi untuk menghapus",
   "profile": "profil",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -111,6 +111,7 @@
   "passwordMinLength": "la password deve contenere almeno 6 caratteri",
   "passwordTooWeak": "la password è troppo debole",
   "planarity": "planarity",
+  "privacyOptions": "opzioni privacy",
   "planarGraphWikipedia": "wikipedia: grafico planare",
   "pressAgainToDelete": "premere nuovamente per eliminare",
   "profile": "profilo",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -111,6 +111,7 @@
   "passwordMinLength": "パスワードは6文字以上なければなりません",
   "passwordTooWeak": "パスワードが弱すぎます",
   "planarity": "planarity",
+  "privacyOptions": "プライバシー設定",
   "planarGraphWikipedia": "wikipedia:平面グラフ",
   "pressAgainToDelete": "もう一度押すと削除されます",
   "profile": "プロフィール",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -111,6 +111,7 @@
   "passwordMinLength": "비밀번호는 최소 6자 이상이어야 합니다",
   "passwordTooWeak": "안전하지 않은 비밀번호입니다",
   "planarity": "planarity",
+  "privacyOptions": "개인정보 옵션",
   "planarGraphWikipedia": "위키백과: 평면 그래프",
   "pressAgainToDelete": "삭제하려면 다시 누르세요.",
   "profile": "프로필",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -111,6 +111,7 @@
   "passwordMinLength": "A palavra-passe deve ter pelo menos 6 caracteres",
   "passwordTooWeak": "A senha é fraca demais!",
   "planarity": "planarity",
+  "privacyOptions": "opções de privacidade",
   "planarGraphWikipedia": "wikipedia: grafo planar",
   "pressAgainToDelete": "prima novamente para eliminar",
   "profile": "perfil",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -111,6 +111,7 @@
   "passwordMinLength": "пароль должен быть не менее 6 символов",
   "passwordTooWeak": "пароль слишком слабый",
   "planarity": "planarity",
+  "privacyOptions": "настройки конфиденциальности",
   "planarGraphWikipedia": "википедия: планарный граф",
   "pressAgainToDelete": "нажмите еще раз, чтобы удалить",
   "profile": "профиль",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -111,6 +111,7 @@
   "passwordMinLength": "şifreniz en az 6 karakter uzunluğunda olmalıdır",
   "passwordTooWeak": "Şifre çok zayıf",
   "planarity": "planarity",
+  "privacyOptions": "gizlilik seçenekleri",
   "planarGraphWikipedia": "wikipedia: düzlemsel grafik",
   "pressAgainToDelete": "silmek için tekrar basın",
   "profile": "profil",

--- a/lib/l10n/app_ur.arb
+++ b/lib/l10n/app_ur.arb
@@ -111,6 +111,7 @@
   "passwordMinLength": "پاس ورڈ لازماً کم از کم 6 حروف و علامات پر مشتمل ہو",
   "passwordTooWeak": "پاس ورڈ بہت کمزور ہے",
   "planarity": "planarity",
+  "privacyOptions": "رازداری کے اختیارات",
   "planarGraphWikipedia": "ویکیپیڈیا: پلینار گراف",
   "pressAgainToDelete": "حذف کرنے کے لیے دوبارہ دبائیں",
   "profile": "پروفائل",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -111,6 +111,7 @@
   "passwordMinLength": "mật khẩu phải có ít nhất 6 ký tự",
   "passwordTooWeak": "mật khẩu quá yếu",
   "planarity": "planarity",
+  "privacyOptions": "tùy chọn quyền riêng tư",
   "planarGraphWikipedia": "wikipedia: đồ thị phẳng",
   "pressAgainToDelete": "nhấn lại để xóa",
   "profile": "hồ sơ",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -111,6 +111,7 @@
   "passwordMinLength": "密码至少需要 6 个字符",
   "passwordTooWeak": "密码太弱",
   "planarity": "planarity",
+  "privacyOptions": "隐私选项",
   "planarGraphWikipedia": "维基百科：平面图",
   "pressAgainToDelete": "再次按下以删除",
   "profile": "个人资料",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -542,6 +542,12 @@ abstract class AppLocalizations {
   /// **'planarity'**
   String get planarity;
 
+  /// No description provided for @privacyOptions.
+  ///
+  /// In en, this message translates to:
+  /// **'privacy options'**
+  String get privacyOptions;
+
   /// No description provided for @planarGraphWikipedia.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -249,6 +249,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get planarity => 'planarity';
 
   @override
+  String get privacyOptions => 'خيارات الخصوصية';
+
+  @override
   String get planarGraphWikipedia => 'ويكيبيديا: رسم بياني مستوٍ';
 
   @override

--- a/lib/l10n/generated/app_localizations_bn.dart
+++ b/lib/l10n/generated/app_localizations_bn.dart
@@ -238,6 +238,9 @@ class AppLocalizationsBn extends AppLocalizations {
   String get planarity => 'planarity';
 
   @override
+  String get privacyOptions => 'গোপনীয়তার বিকল্প';
+
+  @override
   String get planarGraphWikipedia => 'উইকিপিডিয়া: প্ল্যানার গ্রাফ';
 
   @override

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -243,6 +243,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get planarity => 'planarity';
 
   @override
+  String get privacyOptions => 'Datenschutzoptionen';
+
+  @override
   String get planarGraphWikipedia => 'Wikipedia: Planarer Graph';
 
   @override

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -245,6 +245,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get planarity => 'planarity';
 
   @override
+  String get privacyOptions => 'privacy options';
+
+  @override
   String get planarGraphWikipedia => 'wikipedia: planar graph';
 
   @override

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -242,6 +242,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get planarity => 'planarity';
 
   @override
+  String get privacyOptions => 'opciones de privacidad';
+
+  @override
   String get planarGraphWikipedia => 'wikipedia: grafo planar';
 
   @override

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -243,6 +243,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get planarity => 'planarity';
 
   @override
+  String get privacyOptions => 'options de confidentialité';
+
+  @override
   String get planarGraphWikipedia => 'wikipedia : graphe planaire';
 
   @override

--- a/lib/l10n/generated/app_localizations_hi.dart
+++ b/lib/l10n/generated/app_localizations_hi.dart
@@ -239,6 +239,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get planarity => 'planarity';
 
   @override
+  String get privacyOptions => 'गोपनीयता विकल्प';
+
+  @override
   String get planarGraphWikipedia => 'wikipedia: समतलीय ग्राफ';
 
   @override

--- a/lib/l10n/generated/app_localizations_id.dart
+++ b/lib/l10n/generated/app_localizations_id.dart
@@ -239,6 +239,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get planarity => 'planarity';
 
   @override
+  String get privacyOptions => 'opsi privasi';
+
+  @override
   String get planarGraphWikipedia => 'wikipedia: grafik planar';
 
   @override

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -243,6 +243,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get planarity => 'planarity';
 
   @override
+  String get privacyOptions => 'opzioni privacy';
+
+  @override
   String get planarGraphWikipedia => 'wikipedia: grafico planare';
 
   @override

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -229,6 +229,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get planarity => 'planarity';
 
   @override
+  String get privacyOptions => 'プライバシー設定';
+
+  @override
   String get planarGraphWikipedia => 'wikipedia:平面グラフ';
 
   @override

--- a/lib/l10n/generated/app_localizations_ko.dart
+++ b/lib/l10n/generated/app_localizations_ko.dart
@@ -230,6 +230,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get planarity => 'planarity';
 
   @override
+  String get privacyOptions => '개인정보 옵션';
+
+  @override
   String get planarGraphWikipedia => '위키백과: 평면 그래프';
 
   @override

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -240,6 +240,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get planarity => 'planarity';
 
   @override
+  String get privacyOptions => 'opções de privacidade';
+
+  @override
   String get planarGraphWikipedia => 'wikipedia: grafo planar';
 
   @override

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -244,6 +244,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get planarity => 'planarity';
 
   @override
+  String get privacyOptions => 'настройки конфиденциальности';
+
+  @override
   String get planarGraphWikipedia => 'википедия: планарный граф';
 
   @override

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -243,6 +243,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get planarity => 'planarity';
 
   @override
+  String get privacyOptions => 'gizlilik seçenekleri';
+
+  @override
   String get planarGraphWikipedia => 'wikipedia: düzlemsel grafik';
 
   @override

--- a/lib/l10n/generated/app_localizations_ur.dart
+++ b/lib/l10n/generated/app_localizations_ur.dart
@@ -240,6 +240,9 @@ class AppLocalizationsUr extends AppLocalizations {
   String get planarity => 'planarity';
 
   @override
+  String get privacyOptions => 'رازداری کے اختیارات';
+
+  @override
   String get planarGraphWikipedia => 'ویکیپیڈیا: پلینار گراف';
 
   @override

--- a/lib/l10n/generated/app_localizations_vi.dart
+++ b/lib/l10n/generated/app_localizations_vi.dart
@@ -241,6 +241,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get planarity => 'planarity';
 
   @override
+  String get privacyOptions => 'tùy chọn quyền riêng tư';
+
+  @override
   String get planarGraphWikipedia => 'wikipedia: đồ thị phẳng';
 
   @override

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -228,6 +228,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get planarity => 'planarity';
 
   @override
+  String get privacyOptions => '隐私选项';
+
+  @override
   String get planarGraphWikipedia => '维基百科：平面图';
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2423,16 +2423,9 @@ class _HomeHeroContent extends StatelessWidget {
             ),
             if (showAppStoreDownloadButton) ...[
               const SizedBox(height: 12),
-              OutlinedButton.icon(
-                onPressed: onAppStoreTap,
-                style: outlineButtonStyle,
-                icon: const FaIcon(FontAwesomeIcons.apple, size: 18),
-                label: Text(
-                  l10n.downloadOnAppStore,
-                  style: theme.textTheme.bodyLarge?.copyWith(
-                    fontWeight: FontWeight.w500,
-                  ),
-                ),
+              _AppStoreBadge(
+                label: l10n.downloadOnAppStore,
+                onTap: onAppStoreTap,
               ),
             ],
             if (showLeaderboardBelowButton) ...[
@@ -6170,6 +6163,82 @@ class _MoveDots extends StatelessWidget {
             ),
           );
         }),
+      ),
+    );
+  }
+}
+
+class _AppStoreBadge extends StatelessWidget {
+  const _AppStoreBadge({required this.label, required this.onTap});
+
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    const borderRadius = BorderRadius.all(Radius.circular(9));
+
+    return Semantics(
+      button: true,
+      label: label,
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: borderRadius,
+          child: Container(
+            width: 150,
+            height: 50,
+            decoration: BoxDecoration(
+              color: Colors.black,
+              border: Border.all(color: const Color(0xffa6a6a6)),
+              borderRadius: borderRadius,
+            ),
+            child: const ExcludeSemantics(
+              child: Center(
+                child: FittedBox(
+                  fit: BoxFit.contain,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      FaIcon(
+                        FontAwesomeIcons.apple,
+                        color: Colors.white,
+                        size: 31,
+                      ),
+                      SizedBox(width: 9),
+                      Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'Download on the',
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 9.5,
+                              height: 1,
+                              letterSpacing: -0.1,
+                            ),
+                          ),
+                          SizedBox(height: 2),
+                          Text(
+                            'App Store',
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 22.5,
+                              height: 1,
+                              letterSpacing: -0.35,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,9 +28,16 @@ bool _firebaseReady = false;
 bool _googleSignInReady = false;
 FirebaseAnalytics? _analytics;
 FirebaseAnalyticsObserver? _analyticsObserver;
+bool _mobileAdsInitialized = false;
+bool _canRequestMobileAds = false;
+PrivacyOptionsRequirementStatus _privacyOptionsRequirementStatus =
+    PrivacyOptionsRequirementStatus.notRequired;
 
 @visibleForTesting
 bool debugShowAppStoreDownloadButton = false;
+
+@visibleForTesting
+bool debugShowPrivacyOptionsButton = false;
 
 bool get _supportsMobileAds {
   if (kIsWeb) {
@@ -55,21 +62,117 @@ bool get _supportsAppleSignIn {
 }
 
 Future<void> _initializeMobileAds() async {
-  if (!_supportsMobileAds) {
+  if (!_supportsMobileAds || _mobileAdsInitialized) {
     return;
   }
 
   try {
     await MobileAds.instance.initialize();
+    _mobileAdsInitialized = true;
   } catch (error, stackTrace) {
     debugPrint('Mobile Ads initialization failed: $error');
     debugPrintStack(stackTrace: stackTrace);
   }
 }
 
+Future<void> _configureMobileAdsConsent() async {
+  if (!_supportsMobileAds) {
+    return;
+  }
+
+  final consentInformation = ConsentInformation.instance;
+
+  try {
+    await _requestConsentInfoUpdate(consentInformation);
+    await _loadAndShowConsentFormIfRequired();
+  } catch (error, stackTrace) {
+    debugPrint('Mobile Ads consent flow failed: $error');
+    debugPrintStack(stackTrace: stackTrace);
+  }
+
+  await _refreshMobileAdsConsentState();
+  if (_canRequestMobileAds) {
+    await _initializeMobileAds();
+  }
+}
+
+Future<void> _requestConsentInfoUpdate(
+  ConsentInformation consentInformation,
+) async {
+  final completer = Completer<void>();
+  consentInformation.requestConsentInfoUpdate(
+    ConsentRequestParameters(),
+    () {
+      if (!completer.isCompleted) {
+        completer.complete();
+      }
+    },
+    (error) {
+      if (!completer.isCompleted) {
+        completer.completeError(error);
+      }
+    },
+  );
+  await completer.future;
+}
+
+Future<void> _loadAndShowConsentFormIfRequired() async {
+  await ConsentForm.loadAndShowConsentFormIfRequired((error) {
+    if (error != null) {
+      debugPrint('Mobile Ads consent form failed: $error');
+    }
+  });
+}
+
+Future<void> _refreshMobileAdsConsentState() async {
+  if (!_supportsMobileAds) {
+    _canRequestMobileAds = false;
+    _privacyOptionsRequirementStatus =
+        PrivacyOptionsRequirementStatus.notRequired;
+    return;
+  }
+
+  final consentInformation = ConsentInformation.instance;
+  try {
+    final canRequestAds = await consentInformation.canRequestAds();
+    final privacyOptionsRequirementStatus = await consentInformation
+        .getPrivacyOptionsRequirementStatus();
+    _canRequestMobileAds = canRequestAds;
+    _privacyOptionsRequirementStatus = privacyOptionsRequirementStatus;
+  } catch (error, stackTrace) {
+    debugPrint('Mobile Ads consent status failed: $error');
+    debugPrintStack(stackTrace: stackTrace);
+    _canRequestMobileAds = false;
+    _privacyOptionsRequirementStatus =
+        PrivacyOptionsRequirementStatus.notRequired;
+  }
+}
+
+Future<void> _showMobileAdsPrivacyOptionsForm() async {
+  if (!_supportsMobileAds) {
+    return;
+  }
+
+  try {
+    await ConsentForm.showPrivacyOptionsForm((error) {
+      if (error != null) {
+        debugPrint('Mobile Ads privacy options form failed: $error');
+      }
+    });
+  } catch (error, stackTrace) {
+    debugPrint('Mobile Ads privacy options form failed: $error');
+    debugPrintStack(stackTrace: stackTrace);
+  }
+
+  await _refreshMobileAdsConsentState();
+  if (_canRequestMobileAds) {
+    await _initializeMobileAds();
+  }
+}
+
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await _initializeMobileAds();
+  await _configureMobileAdsConsent();
   _firebaseReady = await _initializeFirebase();
   _googleSignInReady = await _initializeGoogleSignIn();
   runApp(const PlanarityApp());
@@ -2046,6 +2149,13 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
     _refreshLeaderboard();
   }
 
+  Future<void> _showPrivacyOptions() async {
+    await _showMobileAdsPrivacyOptionsForm();
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return _buildHomeScaffold(context, _currentUser);
@@ -2157,16 +2267,35 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
                 ),
                 Align(
                   alignment: Alignment.topRight,
-                  child: IconButton(
-                    onPressed: () {
-                      if (user == null) {
-                        _showAuthModal(isSignIn: false);
-                        return;
-                      }
-                      _showProfileModal(user: user);
-                    },
-                    icon: const FaIcon(FontAwesomeIcons.circleUser, size: 22),
-                    tooltip: _l10n.account,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (_privacyOptionsRequirementStatus ==
+                              PrivacyOptionsRequirementStatus.required ||
+                          debugShowPrivacyOptionsButton)
+                        IconButton(
+                          onPressed: _showPrivacyOptions,
+                          icon: const Icon(
+                            Icons.privacy_tip_outlined,
+                            size: 24,
+                          ),
+                          tooltip: _l10n.privacyOptions,
+                        ),
+                      IconButton(
+                        onPressed: () {
+                          if (user == null) {
+                            _showAuthModal(isSignIn: false);
+                            return;
+                          }
+                          _showProfileModal(user: user);
+                        },
+                        icon: const FaIcon(
+                          FontAwesomeIcons.circleUser,
+                          size: 22,
+                        ),
+                        tooltip: _l10n.account,
+                      ),
+                    ],
                   ),
                 ),
               ],
@@ -5224,7 +5353,10 @@ class _PlanarityGamePageState extends State<PlanarityGamePage> {
 
   void _loadInterstitialAd() {
     final adUnitId = _interstitialAdUnitId;
-    if (adUnitId == null || _interstitialAdLoading || _interstitialAd != null) {
+    if (!_canRequestMobileAds ||
+        adUnitId == null ||
+        _interstitialAdLoading ||
+        _interstitialAd != null) {
       return;
     }
 

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -149,6 +149,21 @@ void main() {
     expect(find.text('download on the App Store'), findsOneWidget);
   });
 
+  testWidgets('Home page can show privacy options button', (
+    WidgetTester tester,
+  ) async {
+    debugShowPrivacyOptionsButton = true;
+    addTearDown(() {
+      debugShowPrivacyOptionsButton = false;
+    });
+
+    SharedPreferences.setMockInitialValues({});
+    await tester.pumpWidget(const PlanarityApp());
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.byTooltip('privacy options'), findsOneWidget);
+  });
+
   testWidgets('Home page follows a Spanish system locale', (
     WidgetTester tester,
   ) async {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -146,7 +146,7 @@ void main() {
     await tester.pumpWidget(const PlanarityApp());
     await tester.pump(const Duration(milliseconds: 100));
 
-    expect(find.text('download on the App Store'), findsOneWidget);
+    expect(find.bySemanticsLabel('download on the App Store'), findsOneWidget);
   });
 
   testWidgets('Home page can show privacy options button', (


### PR DESCRIPTION
## Summary
- Requests Google UMP consent info before Mobile Ads startup on mobile platforms.
- Initializes and loads interstitial ads only after UMP reports ads can be requested.
- Adds a localized privacy options entry point and widget coverage for showing it.

## Verification
- `dart format lib/main.dart lib/l10n/app_localizations.dart test/widget_test.dart`
- `flutter analyze` (reports existing informational lints in `lib/main.dart`; no errors after icon fix)
- `flutter test test/widget_test.dart`