### PR TITLE
Issues #84 and #91: Add tutorial and iOS review prompt

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -18,6 +18,7 @@ service cloud.firestore {
         'friends',
         'hiddenDisplayNameUserIds',
         'lastPlayed',
+        'lastRankingSummaryShownFor',
         'lifetimeScore',
         'locked',
         'score',
@@ -73,6 +74,11 @@ service cloud.firestore {
         validLastPlayed(data.appStoreReviewPromptedAt);
     }
 
+    function validOptionalLastRankingSummaryShownFor(data) {
+      return !('lastRankingSummaryShownFor' in data.keys()) ||
+        validLastPlayed(data.lastRankingSummaryShownFor);
+    }
+
     function validUserDocument(data) {
       return data.keys().hasOnly(userFields()) &&
         data.keys().hasAll(requiredUserFields()) &&
@@ -84,6 +90,7 @@ service cloud.firestore {
         validHiddenDisplayNameUserIds(data) &&
         validOptionalTutorialCompleted(data) &&
         validOptionalAppStoreReviewPromptedAt(data) &&
+        validOptionalLastRankingSummaryShownFor(data) &&
         validLastPlayed(data.lastPlayed) &&
         data.locked is bool &&
         data.lifetimeScore is int &&
@@ -161,6 +168,32 @@ service cloud.firestore {
         request.resource.data.createdAt == request.time;
     }
 
+    function validDailyScoreEntry(dayKey, uid) {
+      return signedIn() &&
+        request.auth.uid == uid &&
+        dayKey.matches('^[0-9]{4}-[0-9]{2}-[0-9]{2}$') &&
+        request.resource.data.keys().hasOnly([
+          'displayName',
+          'locked',
+          'score',
+          'uid',
+          'updatedAt'
+        ]) &&
+        request.resource.data.keys().hasAll([
+          'displayName',
+          'locked',
+          'score',
+          'uid',
+          'updatedAt'
+        ]) &&
+        request.resource.data.uid == uid &&
+        validDisplayName(request.resource.data.displayName) &&
+        request.resource.data.locked is bool &&
+        request.resource.data.score is int &&
+        request.resource.data.score >= 0 &&
+        request.resource.data.updatedAt == request.time;
+    }
+
     match /users/{uid} {
       // Global and friends leaderboards read from this collection. The current
       // app stores public leaderboard fields and friend IDs together here.
@@ -174,6 +207,12 @@ service cloud.firestore {
     match /reports/{reportId} {
       allow create: if validReportCreate();
       allow read, update, delete: if false;
+    }
+
+    match /dailyScores/{dayKey}/entries/{uid} {
+      allow read: if true;
+      allow create, update: if validDailyScoreEntry(dayKey, uid);
+      allow delete: if false;
     }
 
     match /{document=**} {

--- a/firestore.rules
+++ b/firestore.rules
@@ -13,6 +13,7 @@ service cloud.firestore {
     function userFields() {
       return [
         'currentLevel',
+        'appStoreReviewPromptedAt',
         'displayName',
         'friends',
         'hiddenDisplayNameUserIds',
@@ -20,6 +21,7 @@ service cloud.firestore {
         'lifetimeScore',
         'locked',
         'score',
+        'tutorialCompleted',
       ];
     }
 
@@ -61,15 +63,27 @@ service cloud.firestore {
         );
     }
 
+    function validOptionalTutorialCompleted(data) {
+      return !('tutorialCompleted' in data.keys()) ||
+        data.tutorialCompleted is bool;
+    }
+
+    function validOptionalAppStoreReviewPromptedAt(data) {
+      return !('appStoreReviewPromptedAt' in data.keys()) ||
+        validLastPlayed(data.appStoreReviewPromptedAt);
+    }
+
     function validUserDocument(data) {
       return data.keys().hasOnly(userFields()) &&
         data.keys().hasAll(requiredUserFields()) &&
         validDisplayName(data.displayName) &&
         data.currentLevel is int &&
-        data.currentLevel >= 4 &&
+        data.currentLevel >= 1 &&
         data.friends is list &&
         validFriends(data.friends) &&
         validHiddenDisplayNameUserIds(data) &&
+        validOptionalTutorialCompleted(data) &&
+        validOptionalAppStoreReviewPromptedAt(data) &&
         validLastPlayed(data.lastPlayed) &&
         data.locked is bool &&
         data.lifetimeScore is int &&

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -97,6 +97,60 @@ String _dayKeyForDate(DateTime date) {
   return '$year-$month-$day';
 }
 
+@visibleForTesting
+class DailyScoreSnapshotEntry {
+  const DailyScoreSnapshotEntry({
+    required this.uid,
+    required this.displayName,
+    required this.score,
+    this.locked = false,
+  });
+
+  final String uid;
+  final String displayName;
+  final int score;
+  final bool locked;
+}
+
+@visibleForTesting
+int? dailyScoreRankFor(List<DailyScoreSnapshotEntry> entries, String uid) {
+  DailyScoreSnapshotEntry? userEntry;
+  for (final entry in entries) {
+    if (entry.uid == uid) {
+      userEntry = entry;
+      break;
+    }
+  }
+  if (userEntry == null) {
+    return null;
+  }
+  return entries.where((entry) => entry.score > userEntry!.score).length + 1;
+}
+
+@visibleForTesting
+Set<String> previousDayWinnerIds(List<DailyScoreSnapshotEntry> entries) {
+  if (entries.isEmpty) {
+    return <String>{};
+  }
+  final topScore = entries.map((entry) => entry.score).reduce(max);
+  return entries
+      .where((entry) => entry.score == topScore)
+      .map((entry) => entry.uid)
+      .toSet();
+}
+
+@visibleForTesting
+bool shouldShowRankingSummary({
+  required String todayKey,
+  required String? previousLastPlayed,
+  required String? lastRankingSummaryShownFor,
+}) {
+  return previousLastPlayed != null &&
+      previousLastPlayed.isNotEmpty &&
+      previousLastPlayed != todayKey &&
+      lastRankingSummaryShownFor != previousLastPlayed;
+}
+
 Future<void> _initializeMobileAds() async {
   if (!_supportsMobileAds || _mobileAdsInitialized) {
     return;
@@ -438,6 +492,8 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
   bool _tutorialCompleted = false;
   String? _previousLastPlayed;
   String? _appStoreReviewPromptedAt;
+  String? _lastRankingSummaryShownFor;
+  bool _rankingSummaryPromptOpen = false;
   int _leaderboardRefreshTick = 0;
   _LeaderboardTab? _selectedLeaderboardTab;
   StreamSubscription<User?>? _authSubscription;
@@ -449,6 +505,8 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
   final Set<String> _reportedUserIdsThisSession = <String>{};
   final Set<String> _hiddenDisplayNameUserIds = <String>{};
   final Set<String> _currentFriendIds = <String>{};
+  final Set<String> _previousDayGlobalWinnerIds = <String>{};
+  final Set<String> _previousDayFriendWinnerIds = <String>{};
   StreamSubscription<Uri>? _appLinkSubscription;
 
   AppLocalizations get _l10n => context.l10n;
@@ -579,6 +637,9 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
       _tutorialCompleted = tutorialCompleted;
       _previousLastPlayed = lastPlayed;
       _appStoreReviewPromptedAt = _profileAppStoreReviewPromptedAt(profileData);
+      _lastRankingSummaryShownFor = _profileLastRankingSummaryShownFor(
+        profileData,
+      );
       _isLoaded = true;
       _hiddenDisplayNameUserIds
         ..clear()
@@ -593,12 +654,16 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
       }
     });
     _refreshLeaderboard();
+    unawaited(_refreshPreviousDayWinnerBadges(user, profileData));
     if (user == null) {
       _maybePromptToAuthenticateForFriendInvite();
       return;
     }
 
     _maybePromptToAddIncomingFriend(profileData: profileData);
+    unawaited(
+      _maybeShowRankingSummaryModal(user: user, profileData: profileData),
+    );
 
     if (!playedToday &&
         (isLocked ||
@@ -621,6 +686,7 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
       'friends': <String>[],
       'hiddenDisplayNameUserIds': <String>[],
       'lastPlayed': '',
+      'lastRankingSummaryShownFor': '',
       'locked': false,
       'lifetimeScore': 0,
       'score': 0,
@@ -692,6 +758,7 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
     int? lifetimeScoreIncrement,
     bool? tutorialCompleted,
     String? appStoreReviewPromptedAt,
+    String? lastRankingSummaryShownFor,
   }) async {
     if (user != null) {
       await _updateUserProgressFields(
@@ -703,6 +770,7 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
         lifetimeScoreIncrement: lifetimeScoreIncrement,
         tutorialCompleted: tutorialCompleted,
         appStoreReviewPromptedAt: appStoreReviewPromptedAt,
+        lastRankingSummaryShownFor: lastRankingSummaryShownFor,
       );
       return;
     }
@@ -730,6 +798,9 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
     if (appStoreReviewPromptedAt != null) {
       localDocument['appStoreReviewPromptedAt'] = appStoreReviewPromptedAt;
     }
+    if (lastRankingSummaryShownFor != null) {
+      localDocument['lastRankingSummaryShownFor'] = lastRankingSummaryShownFor;
+    }
     await _saveLocalGuestUserDocument(localDocument);
   }
 
@@ -742,6 +813,7 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
     int? lifetimeScoreIncrement,
     bool? tutorialCompleted,
     String? appStoreReviewPromptedAt,
+    String? lastRankingSummaryShownFor,
   }) async {
     final data = <String, Object>{};
     if (score != null) {
@@ -765,6 +837,9 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
     if (appStoreReviewPromptedAt != null) {
       data['appStoreReviewPromptedAt'] = appStoreReviewPromptedAt;
     }
+    if (lastRankingSummaryShownFor != null) {
+      data['lastRankingSummaryShownFor'] = lastRankingSummaryShownFor;
+    }
     if (data.isEmpty) {
       return;
     }
@@ -773,6 +848,26 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
         .collection('users')
         .doc(userId)
         .set(data, SetOptions(merge: true));
+  }
+
+  Future<void> _writeDailyScoreSnapshot({
+    required User user,
+    required String dayKey,
+    required int score,
+    required bool locked,
+  }) async {
+    await FirebaseFirestore.instance
+        .collection('dailyScores')
+        .doc(dayKey)
+        .collection('entries')
+        .doc(user.uid)
+        .set({
+          'uid': user.uid,
+          'displayName': _displayNameForUser(user, l10n: _l10n),
+          'score': max(0, score),
+          'locked': locked,
+          'updatedAt': FieldValue.serverTimestamp(),
+        }, SetOptions(merge: true));
   }
 
   Future<SharedPreferences?> _prefsOrNull() async {
@@ -820,6 +915,15 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
       lastPlayed: today,
       locked: false,
     );
+    final currentUser = _currentUser;
+    if (currentUser != null) {
+      await _writeDailyScoreSnapshot(
+        user: currentUser,
+        dayKey: today,
+        score: _score,
+        locked: false,
+      );
+    }
     if (!mounted) {
       return;
     }
@@ -864,6 +968,15 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
       lifetimeScoreIncrement: max(0, result.score - previousScore),
       tutorialCompleted: result.tutorialCompleted,
     );
+    final resultUser = _currentUser;
+    if (resultUser != null) {
+      await _writeDailyScoreSnapshot(
+        user: resultUser,
+        dayKey: result.dayKey,
+        score: result.score,
+        locked: result.locked,
+      );
+    }
     await _logPostScoreEvent(score: result.score, level: result.level);
     _refreshLeaderboard();
   }
@@ -914,6 +1027,178 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
         debugPrint('Unable to save App Store review prompt state: $error');
         debugPrintStack(stackTrace: stackTrace);
       }
+    }
+  }
+
+  Future<void> _refreshPreviousDayWinnerBadges(
+    User? user,
+    Map<String, dynamic>? profileData,
+  ) async {
+    if (!_firebaseReady) {
+      return;
+    }
+    final yesterday = previousDayKey(_todayKey());
+    if (yesterday == null) {
+      return;
+    }
+
+    try {
+      final globalWinners = await _loadGlobalDailyWinnerIds(yesterday);
+      final friendIds = user == null
+          ? const <String>[]
+          : <String>{user.uid, ..._profileFriendIds(profileData)}.toList();
+      final friendEntries = await _loadDailyScoreEntriesForUids(
+        dayKey: yesterday,
+        userIds: friendIds,
+      );
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _previousDayGlobalWinnerIds
+          ..clear()
+          ..addAll(globalWinners);
+        _previousDayFriendWinnerIds
+          ..clear()
+          ..addAll(previousDayWinnerIds(friendEntries));
+      });
+    } catch (error, stackTrace) {
+      debugPrint('Unable to load previous day winners: $error');
+      debugPrintStack(stackTrace: stackTrace);
+    }
+  }
+
+  Future<Set<String>> _loadGlobalDailyWinnerIds(String dayKey) async {
+    final entries = FirebaseFirestore.instance
+        .collection('dailyScores')
+        .doc(dayKey)
+        .collection('entries');
+    final topSnapshot = await entries
+        .orderBy('score', descending: true)
+        .limit(1)
+        .get();
+    if (topSnapshot.docs.isEmpty) {
+      return <String>{};
+    }
+    final topScore = _dailyScoreEntryFromSnapshot(topSnapshot.docs.first).score;
+    final tiedTopSnapshot = await entries
+        .where('score', isEqualTo: topScore)
+        .get();
+    return tiedTopSnapshot.docs.map((doc) => doc.id).toSet();
+  }
+
+  Future<List<DailyScoreSnapshotEntry>> _loadDailyScoreEntriesForUids({
+    required String dayKey,
+    required List<String> userIds,
+  }) async {
+    if (userIds.isEmpty) {
+      return const <DailyScoreSnapshotEntry>[];
+    }
+    final entries = FirebaseFirestore.instance
+        .collection('dailyScores')
+        .doc(dayKey)
+        .collection('entries');
+    final snapshots = await Future.wait(
+      userIds.toSet().map((uid) => entries.doc(uid).get()),
+    );
+    return snapshots
+        .where((snapshot) => snapshot.exists)
+        .map(_dailyScoreEntryFromSnapshot)
+        .toList(growable: false);
+  }
+
+  DailyScoreSnapshotEntry _dailyScoreEntryFromSnapshot(
+    DocumentSnapshot<Map<String, dynamic>> snapshot,
+  ) {
+    final data = snapshot.data() ?? const <String, dynamic>{};
+    final displayName = data['displayName'];
+    final score = data['score'];
+    final locked = data['locked'];
+    return DailyScoreSnapshotEntry(
+      uid: snapshot.id,
+      displayName: displayName is String && displayName.trim().isNotEmpty
+          ? displayName.trim()
+          : _l10n.anonymousPlayer,
+      score: score is int
+          ? max(0, score)
+          : (score is num ? max(0, score.toInt()) : 0),
+      locked: locked is bool && locked,
+    );
+  }
+
+  Future<void> _maybeShowRankingSummaryModal({
+    required User user,
+    required Map<String, dynamic>? profileData,
+  }) async {
+    final summaryDay = _profileLastPlayed(profileData);
+    if (!_firebaseReady ||
+        _rankingSummaryPromptOpen ||
+        !shouldShowRankingSummary(
+          todayKey: _todayKey(),
+          previousLastPlayed: summaryDay,
+          lastRankingSummaryShownFor: _lastRankingSummaryShownFor,
+        )) {
+      return;
+    }
+
+    _rankingSummaryPromptOpen = true;
+    try {
+      final entries = FirebaseFirestore.instance
+          .collection('dailyScores')
+          .doc(summaryDay!)
+          .collection('entries');
+      final userSnapshot = await entries.doc(user.uid).get();
+      if (!mounted || !userSnapshot.exists) {
+        return;
+      }
+      final userEntry = _dailyScoreEntryFromSnapshot(userSnapshot);
+      final globalRankSnapshot = await entries
+          .where('score', isGreaterThan: userEntry.score)
+          .count()
+          .get();
+      final globalRank = (globalRankSnapshot.count ?? 0) + 1;
+      final globalTopSnapshot = await entries
+          .orderBy('score', descending: true)
+          .limit(10)
+          .get();
+      final globalEntries = <DailyScoreSnapshotEntry>[
+        ...globalTopSnapshot.docs.map(_dailyScoreEntryFromSnapshot),
+      ];
+      if (!globalEntries.any((entry) => entry.uid == user.uid)) {
+        globalEntries.add(userEntry);
+      }
+      final friendEntries = await _loadDailyScoreEntriesForUids(
+        dayKey: summaryDay,
+        userIds: <String>{user.uid, ..._profileFriendIds(profileData)}.toList(),
+      );
+      final friendRank = dailyScoreRankFor(friendEntries, user.uid);
+      if (!mounted) {
+        return;
+      }
+      await showDialog<void>(
+        context: context,
+        builder: (dialogContext) => _RankingSummaryDialog(
+          dayKey: summaryDay,
+          friendRank: friendRank,
+          globalRank: globalRank,
+          friendEntries: friendEntries,
+          globalEntries: globalEntries,
+          currentUserId: user.uid,
+        ),
+      );
+      if (!mounted) {
+        return;
+      }
+      _lastRankingSummaryShownFor = summaryDay;
+      await _updateCurrentUserProgressFields(
+        user: user,
+        lastRankingSummaryShownFor: summaryDay,
+      );
+    } catch (error, stackTrace) {
+      debugPrint('Unable to show ranking summary: $error');
+      debugPrintStack(stackTrace: stackTrace);
+    } finally {
+      _rankingSummaryPromptOpen = false;
     }
   }
 
@@ -1651,6 +1936,16 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
     return null;
   }
 
+  String? _profileLastRankingSummaryShownFor(
+    Map<String, dynamic>? profileData,
+  ) {
+    final shownFor = profileData?['lastRankingSummaryShownFor'];
+    if (shownFor is String && shownFor.isNotEmpty) {
+      return shownFor;
+    }
+    return null;
+  }
+
   String? _profileLastPlayed(Map<String, dynamic>? profileData) {
     final lastPlayed = profileData?['lastPlayed'];
     if (lastPlayed is String && lastPlayed.isNotEmpty) {
@@ -2367,6 +2662,8 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
         reportedUserIds: _reportedUserIdsThisSession,
         hiddenDisplayNameUserIds: _hiddenDisplayNameUserIds,
         onToggleHiddenDisplayName: _toggleHiddenDisplayName,
+        previousDayFriendWinnerIds: _previousDayFriendWinnerIds,
+        previousDayGlobalWinnerIds: _previousDayGlobalWinnerIds,
         selectedTab: selectedLeaderboardTab,
         onTabSelected: (_LeaderboardTab tab) {
           setState(() {
@@ -2410,6 +2707,10 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
                                       _hiddenDisplayNameUserIds,
                                   onToggleHiddenDisplayName:
                                       _toggleHiddenDisplayName,
+                                  previousDayFriendWinnerIds:
+                                      _previousDayFriendWinnerIds,
+                                  previousDayGlobalWinnerIds:
+                                      _previousDayGlobalWinnerIds,
                                   selectedTab: selectedLeaderboardTab,
                                   onTabSelected: (_LeaderboardTab tab) {
                                     setState(() {
@@ -4195,6 +4496,8 @@ class _LeaderboardCard extends StatelessWidget {
     required this.reportedUserIds,
     required this.hiddenDisplayNameUserIds,
     required this.onToggleHiddenDisplayName,
+    required this.previousDayFriendWinnerIds,
+    required this.previousDayGlobalWinnerIds,
     required this.selectedTab,
     required this.onTabSelected,
   });
@@ -4211,6 +4514,8 @@ class _LeaderboardCard extends StatelessWidget {
   final Set<String> reportedUserIds;
   final Set<String> hiddenDisplayNameUserIds;
   final ValueChanged<String> onToggleHiddenDisplayName;
+  final Set<String> previousDayFriendWinnerIds;
+  final Set<String> previousDayGlobalWinnerIds;
   final _LeaderboardTab selectedTab;
   final ValueChanged<_LeaderboardTab> onTabSelected;
 
@@ -4235,6 +4540,8 @@ class _LeaderboardCard extends StatelessWidget {
         reportedUserIds: reportedUserIds,
         hiddenDisplayNameUserIds: hiddenDisplayNameUserIds,
         onToggleHiddenDisplayName: onToggleHiddenDisplayName,
+        previousDayFriendWinnerIds: previousDayFriendWinnerIds,
+        previousDayGlobalWinnerIds: previousDayGlobalWinnerIds,
         selectedTab: selectedTab,
         onTabSelected: onTabSelected,
       ),
@@ -4251,6 +4558,8 @@ class _LeaderboardCardContents extends StatelessWidget {
     required this.reportedUserIds,
     required this.hiddenDisplayNameUserIds,
     required this.onToggleHiddenDisplayName,
+    required this.previousDayFriendWinnerIds,
+    required this.previousDayGlobalWinnerIds,
     required this.selectedTab,
     required this.onTabSelected,
   });
@@ -4267,6 +4576,8 @@ class _LeaderboardCardContents extends StatelessWidget {
   final Set<String> reportedUserIds;
   final Set<String> hiddenDisplayNameUserIds;
   final ValueChanged<String> onToggleHiddenDisplayName;
+  final Set<String> previousDayFriendWinnerIds;
+  final Set<String> previousDayGlobalWinnerIds;
   final _LeaderboardTab selectedTab;
   final ValueChanged<_LeaderboardTab> onTabSelected;
 
@@ -4319,6 +4630,7 @@ class _LeaderboardCardContents extends StatelessWidget {
                   reportedUserIds: reportedUserIds,
                   hiddenDisplayNameUserIds: hiddenDisplayNameUserIds,
                   onToggleHiddenDisplayName: onToggleHiddenDisplayName,
+                  previousDayWinnerIds: previousDayFriendWinnerIds,
                 )
               : _GlobalLeaderboardView(
                   key: const ValueKey('global'),
@@ -4327,6 +4639,7 @@ class _LeaderboardCardContents extends StatelessWidget {
                   reportedUserIds: reportedUserIds,
                   hiddenDisplayNameUserIds: hiddenDisplayNameUserIds,
                   onToggleHiddenDisplayName: onToggleHiddenDisplayName,
+                  previousDayWinnerIds: previousDayGlobalWinnerIds,
                 ),
         ),
       ],
@@ -4382,6 +4695,7 @@ class _FriendsLeaderboardView extends StatefulWidget {
     required this.reportedUserIds,
     required this.hiddenDisplayNameUserIds,
     required this.onToggleHiddenDisplayName,
+    required this.previousDayWinnerIds,
   });
 
   final User? user;
@@ -4396,6 +4710,7 @@ class _FriendsLeaderboardView extends StatefulWidget {
   final Set<String> reportedUserIds;
   final Set<String> hiddenDisplayNameUserIds;
   final ValueChanged<String> onToggleHiddenDisplayName;
+  final Set<String> previousDayWinnerIds;
 
   @override
   State<_FriendsLeaderboardView> createState() =>
@@ -4641,6 +4956,7 @@ class _FriendsLeaderboardViewState extends State<_FriendsLeaderboardView> {
       reportedUserIds: widget.reportedUserIds,
       hiddenDisplayNameUserIds: widget.hiddenDisplayNameUserIds,
       onToggleHiddenDisplayName: widget.onToggleHiddenDisplayName,
+      previousDayWinnerIds: widget.previousDayWinnerIds,
       onReport: (entry) => widget.onReportUser(
         reportedUid: entry.uid,
         reportedDisplayName: entry.name,
@@ -4723,6 +5039,7 @@ class _GlobalLeaderboardView extends StatefulWidget {
     required this.reportedUserIds,
     required this.hiddenDisplayNameUserIds,
     required this.onToggleHiddenDisplayName,
+    required this.previousDayWinnerIds,
   });
 
   final User? user;
@@ -4735,6 +5052,7 @@ class _GlobalLeaderboardView extends StatefulWidget {
   final Set<String> reportedUserIds;
   final Set<String> hiddenDisplayNameUserIds;
   final ValueChanged<String> onToggleHiddenDisplayName;
+  final Set<String> previousDayWinnerIds;
 
   @override
   State<_GlobalLeaderboardView> createState() => _GlobalLeaderboardViewState();
@@ -5174,6 +5492,7 @@ class _GlobalLeaderboardViewState extends State<_GlobalLeaderboardView> {
           reportedUserIds: widget.reportedUserIds,
           hiddenDisplayNameUserIds: widget.hiddenDisplayNameUserIds,
           onToggleHiddenDisplayName: widget.onToggleHiddenDisplayName,
+          previousDayWinnerIds: widget.previousDayWinnerIds,
           onReport: _user == null
               ? null
               : (entry) => widget.onReportUser(
@@ -5229,6 +5548,168 @@ class _LeaderboardMetric extends StatelessWidget {
   }
 }
 
+class _RankingSummaryDialog extends StatelessWidget {
+  const _RankingSummaryDialog({
+    required this.dayKey,
+    required this.friendRank,
+    required this.globalRank,
+    required this.friendEntries,
+    required this.globalEntries,
+    required this.currentUserId,
+  });
+
+  final String dayKey;
+  final int? friendRank;
+  final int globalRank;
+  final List<DailyScoreSnapshotEntry> friendEntries;
+  final List<DailyScoreSnapshotEntry> globalEntries;
+  final String currentUserId;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Dialog(
+      backgroundColor: theme.colorScheme.surface,
+      surfaceTintColor: Colors.transparent,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.zero,
+        side: BorderSide(color: theme.colorScheme.onSurface.withOpacity(0.35)),
+      ),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 520),
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(18),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'ranking update',
+                style: theme.textTheme.titleLarge?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 10),
+              Text(
+                friendRank == null
+                    ? 'you ranked #$globalRank globally on $dayKey'
+                    : 'you ranked #$friendRank among friends and #$globalRank globally on $dayKey',
+                style: theme.textTheme.bodyMedium,
+              ),
+              const SizedBox(height: 18),
+              if (friendEntries.isNotEmpty) ...[
+                _DailyScoreSnapshotTable(
+                  title: 'friends',
+                  entries: friendEntries,
+                  currentUserId: currentUserId,
+                ),
+                const SizedBox(height: 18),
+              ],
+              _DailyScoreSnapshotTable(
+                title: 'global',
+                entries: globalEntries,
+                currentUserId: currentUserId,
+              ),
+              const SizedBox(height: 16),
+              Align(
+                alignment: Alignment.centerRight,
+                child: FilledButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('continue'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DailyScoreSnapshotTable extends StatelessWidget {
+  const _DailyScoreSnapshotTable({
+    required this.title,
+    required this.entries,
+    required this.currentUserId,
+  });
+
+  final String title;
+  final List<DailyScoreSnapshotEntry> entries;
+  final String currentUserId;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final sortedEntries = List<DailyScoreSnapshotEntry>.from(entries)
+      ..sort((a, b) {
+        final byScore = b.score.compareTo(a.score);
+        if (byScore != 0) {
+          return byScore;
+        }
+        final byName = a.displayName.toLowerCase().compareTo(
+          b.displayName.toLowerCase(),
+        );
+        if (byName != 0) {
+          return byName;
+        }
+        return a.uid.compareTo(b.uid);
+      });
+    final winnerIds = previousDayWinnerIds(entries);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          title,
+          style: theme.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        const SizedBox(height: 8),
+        ...sortedEntries.map((entry) {
+          final isCurrentUser = entry.uid == currentUserId;
+          final rank = dailyScoreRankFor(entries, entry.uid) ?? 0;
+          return Padding(
+            padding: const EdgeInsets.only(bottom: 8),
+            child: Row(
+              children: [
+                SizedBox(width: 42, child: Text('#$rank')),
+                Expanded(
+                  child: Row(
+                    children: [
+                      Flexible(
+                        child: Text(
+                          entry.displayName,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            fontWeight: isCurrentUser
+                                ? FontWeight.w800
+                                : FontWeight.w500,
+                          ),
+                        ),
+                      ),
+                      if (winnerIds.contains(entry.uid)) ...[
+                        const SizedBox(width: 6),
+                        const Icon(Icons.emoji_events, size: 16),
+                      ],
+                    ],
+                  ),
+                ),
+                Text(
+                  '${entry.score}',
+                  style: theme.textTheme.bodyLarge?.copyWith(
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+              ],
+            ),
+          );
+        }),
+      ],
+    );
+  }
+}
+
 class _LeaderboardTable extends StatelessWidget {
   const _LeaderboardTable({
     required this.entries,
@@ -5236,6 +5717,7 @@ class _LeaderboardTable extends StatelessWidget {
     required this.reportedUserIds,
     required this.hiddenDisplayNameUserIds,
     required this.onToggleHiddenDisplayName,
+    required this.previousDayWinnerIds,
     this.onReport,
   });
 
@@ -5244,6 +5726,7 @@ class _LeaderboardTable extends StatelessWidget {
   final Set<String> reportedUserIds;
   final Set<String> hiddenDisplayNameUserIds;
   final ValueChanged<String> onToggleHiddenDisplayName;
+  final Set<String> previousDayWinnerIds;
   final ValueChanged<_LeaderboardEntry>? onReport;
 
   @override
@@ -5306,13 +5789,27 @@ class _LeaderboardTable extends StatelessWidget {
                   ),
                 ),
                 Expanded(
-                  child: Text(
-                    displayName,
-                    overflow: TextOverflow.ellipsis,
-                    style: theme.textTheme.bodyMedium?.copyWith(
-                      fontWeight: FontWeight.w700,
-                      color: rowForeground,
-                    ),
+                  child: Row(
+                    children: [
+                      Flexible(
+                        child: Text(
+                          displayName,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            fontWeight: FontWeight.w700,
+                            color: rowForeground,
+                          ),
+                        ),
+                      ),
+                      if (previousDayWinnerIds.contains(entry.uid)) ...[
+                        const SizedBox(width: 6),
+                        Icon(
+                          Icons.emoji_events,
+                          size: 16,
+                          color: rowForeground,
+                        ),
+                      ],
+                    ],
                   ),
                 ),
                 const SizedBox(width: 12),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,7 @@ import 'package:flutter/services.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:google_sign_in/google_sign_in.dart';
+import 'package:in_app_review/in_app_review.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:share_plus/share_plus.dart';
@@ -59,6 +60,41 @@ bool get _supportsAppleSignIn {
     TargetPlatform.iOS || TargetPlatform.macOS => true,
     _ => false,
   };
+}
+
+@visibleForTesting
+bool shouldPromptForAppStoreReview({
+  required TargetPlatform platform,
+  required bool isWeb,
+  required bool signedIn,
+  required String? previousLastPlayed,
+  required String todayKey,
+  required String? appStoreReviewPromptedAt,
+}) {
+  if (isWeb || platform != TargetPlatform.iOS || !signedIn) {
+    return false;
+  }
+  if (appStoreReviewPromptedAt != null && appStoreReviewPromptedAt.isNotEmpty) {
+    return false;
+  }
+  return previousLastPlayed == previousDayKey(todayKey);
+}
+
+@visibleForTesting
+String? previousDayKey(String dayKey) {
+  final parsed = DateTime.tryParse(dayKey);
+  if (parsed == null) {
+    return null;
+  }
+  final previousDay = parsed.subtract(const Duration(days: 1));
+  return _dayKeyForDate(previousDay);
+}
+
+String _dayKeyForDate(DateTime date) {
+  final year = date.year.toString().padLeft(4, '0');
+  final month = date.month.toString().padLeft(2, '0');
+  final day = date.day.toString().padLeft(2, '0');
+  return '$year-$month-$day';
 }
 
 Future<void> _initializeMobileAds() async {
@@ -391,13 +427,17 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
   static final Uri _planarGraphInfoUri = Uri.parse(
     'https://en.wikipedia.org/wiki/Planar_graph',
   );
-  static const _startingLevel = 4;
+  static const _tutorialStartLevel = 1;
+  static const _normalStartLevel = 4;
   static const _localGuestUserDocumentKey = 'local_guest_user_document';
 
   bool _isLoaded = false;
   DailyPlayStatus _status = DailyPlayStatus.ready;
-  int _currentLevel = _startingLevel;
+  int _currentLevel = _tutorialStartLevel;
   int _score = 0;
+  bool _tutorialCompleted = false;
+  String? _previousLastPlayed;
+  String? _appStoreReviewPromptedAt;
   int _leaderboardRefreshTick = 0;
   _LeaderboardTab? _selectedLeaderboardTab;
   StreamSubscription<User?>? _authSubscription;
@@ -510,10 +550,12 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
     final signedInChanged = (_currentUser != null) != (user != null);
     final lastPlayed = _profileLastPlayed(profileData);
     final playedToday = lastPlayed == _todayKey();
+    final tutorialCompleted = _profileTutorialCompleted(profileData);
     final syncedScore = _profileScore(profileData, playedToday: playedToday);
     final syncedLevel = _profileCurrentLevel(
       profileData,
       playedToday: playedToday,
+      tutorialCompleted: tutorialCompleted,
     );
     final isLocked = _profileLocked(profileData);
     final hiddenDisplayNameUserIds = _profileHiddenDisplayNameUserIds(
@@ -534,6 +576,9 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
           : DailyPlayStatus.ready;
       _currentLevel = syncedLevel;
       _score = syncedScore;
+      _tutorialCompleted = tutorialCompleted;
+      _previousLastPlayed = lastPlayed;
+      _appStoreReviewPromptedAt = _profileAppStoreReviewPromptedAt(profileData);
       _isLoaded = true;
       _hiddenDisplayNameUserIds
         ..clear()
@@ -556,11 +601,13 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
     _maybePromptToAddIncomingFriend(profileData: profileData);
 
     if (!playedToday &&
-        (isLocked || syncedScore != 0 || syncedLevel != _startingLevel)) {
+        (isLocked ||
+            syncedScore != 0 ||
+            syncedLevel != _startLevelForTutorial(tutorialCompleted))) {
       await _updateCurrentUserProgressFields(
         user: user,
         score: 0,
-        currentLevel: _startingLevel,
+        currentLevel: _startLevelForTutorial(tutorialCompleted),
         locked: false,
       );
     }
@@ -569,13 +616,15 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
   Map<String, dynamic> _defaultUserDocument({String? displayName}) {
     return <String, dynamic>{
       'displayName': displayName ?? _l10n.anonymousPlayer,
-      'currentLevel': _startingLevel,
+      'currentLevel': _tutorialStartLevel,
+      'appStoreReviewPromptedAt': '',
       'friends': <String>[],
       'hiddenDisplayNameUserIds': <String>[],
       'lastPlayed': '',
       'locked': false,
       'lifetimeScore': 0,
       'score': 0,
+      'tutorialCompleted': false,
     };
   }
 
@@ -641,6 +690,8 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
     String? lastPlayed,
     bool? locked,
     int? lifetimeScoreIncrement,
+    bool? tutorialCompleted,
+    String? appStoreReviewPromptedAt,
   }) async {
     if (user != null) {
       await _updateUserProgressFields(
@@ -650,6 +701,8 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
         lastPlayed: lastPlayed,
         locked: locked,
         lifetimeScoreIncrement: lifetimeScoreIncrement,
+        tutorialCompleted: tutorialCompleted,
+        appStoreReviewPromptedAt: appStoreReviewPromptedAt,
       );
       return;
     }
@@ -671,6 +724,12 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
       localDocument['lifetimeScore'] =
           _profileLifetimeScore(localDocument) + lifetimeScoreIncrement;
     }
+    if (tutorialCompleted != null) {
+      localDocument['tutorialCompleted'] = tutorialCompleted;
+    }
+    if (appStoreReviewPromptedAt != null) {
+      localDocument['appStoreReviewPromptedAt'] = appStoreReviewPromptedAt;
+    }
     await _saveLocalGuestUserDocument(localDocument);
   }
 
@@ -681,6 +740,8 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
     String? lastPlayed,
     bool? locked,
     int? lifetimeScoreIncrement,
+    bool? tutorialCompleted,
+    String? appStoreReviewPromptedAt,
   }) async {
     final data = <String, Object>{};
     if (score != null) {
@@ -697,6 +758,12 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
     }
     if (lifetimeScoreIncrement != null && lifetimeScoreIncrement > 0) {
       data['lifetimeScore'] = FieldValue.increment(lifetimeScoreIncrement);
+    }
+    if (tutorialCompleted != null) {
+      data['tutorialCompleted'] = tutorialCompleted;
+    }
+    if (appStoreReviewPromptedAt != null) {
+      data['appStoreReviewPromptedAt'] = appStoreReviewPromptedAt;
     }
     if (data.isEmpty) {
       return;
@@ -753,6 +820,9 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
       lastPlayed: today,
       locked: false,
     );
+    if (!mounted) {
+      return;
+    }
     final result = await Navigator.of(context).push<GameSessionResult>(
       MaterialPageRoute(
         settings: const RouteSettings(name: 'game_session'),
@@ -760,6 +830,8 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
           dayKey: today,
           startLevel: startLevel,
           startScore: startScore,
+          tutorialCompleted: _tutorialCompleted,
+          onLevelSolved: _handleLevelSolved,
         ),
       ),
     );
@@ -781,6 +853,7 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
         _status = DailyPlayStatus.inProgress;
         _currentLevel = result.level;
       }
+      _tutorialCompleted = result.tutorialCompleted;
     });
     await _updateCurrentUserProgressFields(
       user: _currentUser,
@@ -789,9 +862,59 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
       lastPlayed: result.dayKey,
       locked: result.locked,
       lifetimeScoreIncrement: max(0, result.score - previousScore),
+      tutorialCompleted: result.tutorialCompleted,
     );
     await _logPostScoreEvent(score: result.score, level: result.level);
     _refreshLeaderboard();
+  }
+
+  Future<void> _handleLevelSolved(int level) async {
+    if (level == 3 && !_tutorialCompleted) {
+      _tutorialCompleted = true;
+      try {
+        await _updateCurrentUserProgressFields(
+          user: _currentUser,
+          currentLevel: _normalStartLevel,
+          tutorialCompleted: true,
+        );
+      } catch (error, stackTrace) {
+        debugPrint('Unable to save tutorial completion: $error');
+        debugPrintStack(stackTrace: stackTrace);
+      }
+    }
+
+    if (level != 5 ||
+        !shouldPromptForAppStoreReview(
+          platform: defaultTargetPlatform,
+          isWeb: kIsWeb,
+          signedIn: _currentUser != null,
+          previousLastPlayed: _previousLastPlayed,
+          todayKey: _todayKey(),
+          appStoreReviewPromptedAt: _appStoreReviewPromptedAt,
+        )) {
+      return;
+    }
+
+    try {
+      final inAppReview = InAppReview.instance;
+      if (await inAppReview.isAvailable()) {
+        await inAppReview.requestReview();
+      }
+    } on MissingPluginException {
+      return;
+    } finally {
+      final today = _todayKey();
+      _appStoreReviewPromptedAt = today;
+      try {
+        await _updateCurrentUserProgressFields(
+          user: _currentUser,
+          appStoreReviewPromptedAt: today,
+        );
+      } catch (error, stackTrace) {
+        debugPrint('Unable to save App Store review prompt state: $error');
+        debugPrintStack(stackTrace: stackTrace);
+      }
+    }
   }
 
   Future<String?> _submitAuth({
@@ -1468,18 +1591,64 @@ class _PlanarityHomePageState extends State<PlanarityHomePage>
   int _profileCurrentLevel(
     Map<String, dynamic>? profileData, {
     required bool playedToday,
+    required bool tutorialCompleted,
   }) {
+    final startLevel = _startLevelForTutorial(tutorialCompleted);
     if (!playedToday) {
-      return _startingLevel;
+      return startLevel;
     }
     final currentLevel = profileData?['currentLevel'];
     if (currentLevel is int) {
-      return max(_startingLevel, currentLevel);
+      return max(startLevel, currentLevel);
     }
     if (currentLevel is num) {
-      return max(_startingLevel, currentLevel.toInt());
+      return max(startLevel, currentLevel.toInt());
     }
-    return _startingLevel;
+    return startLevel;
+  }
+
+  int _startLevelForTutorial(bool tutorialCompleted) {
+    return tutorialCompleted ? _normalStartLevel : _tutorialStartLevel;
+  }
+
+  bool _profileTutorialCompleted(Map<String, dynamic>? profileData) {
+    final tutorialCompleted = profileData?['tutorialCompleted'];
+    if (tutorialCompleted is bool) {
+      return tutorialCompleted;
+    }
+    return _profileHasPriorProgress(profileData);
+  }
+
+  bool _profileHasPriorProgress(Map<String, dynamic>? profileData) {
+    final lastPlayed = _profileLastPlayed(profileData);
+    if (lastPlayed != null) {
+      return true;
+    }
+    if (_profileLifetimeScore(profileData) > 0) {
+      return true;
+    }
+    if (_leaderboardRawScoreFromData(profileData) > 0) {
+      return true;
+    }
+    if (_profileLocked(profileData)) {
+      return true;
+    }
+    final currentLevel = profileData?['currentLevel'];
+    if (currentLevel is int) {
+      return currentLevel > _normalStartLevel;
+    }
+    if (currentLevel is num) {
+      return currentLevel.toInt() > _normalStartLevel;
+    }
+    return false;
+  }
+
+  String? _profileAppStoreReviewPromptedAt(Map<String, dynamic>? profileData) {
+    final promptedAt = profileData?['appStoreReviewPromptedAt'];
+    if (promptedAt is String && promptedAt.isNotEmpty) {
+      return promptedAt;
+    }
+    return null;
   }
 
   String? _profileLastPlayed(Map<String, dynamic>? profileData) {
@@ -5257,11 +5426,15 @@ class PlanarityGamePage extends StatefulWidget {
     required this.dayKey,
     required this.startLevel,
     required this.startScore,
+    required this.tutorialCompleted,
+    this.onLevelSolved,
   });
 
   final String dayKey;
   final int startLevel;
   final int startScore;
+  final bool tutorialCompleted;
+  final Future<void> Function(int level)? onLevelSolved;
 
   @override
   State<PlanarityGamePage> createState() => _PlanarityGamePageState();
@@ -5280,6 +5453,7 @@ class _PlanarityGamePageState extends State<PlanarityGamePage> {
   late int _level;
   late int _totalScore;
   late PlanarityLevel _current;
+  late bool _tutorialCompleted;
   int _movesUsed = 0;
   int? _activeNode;
   Offset? _dragStart;
@@ -5297,6 +5471,7 @@ class _PlanarityGamePageState extends State<PlanarityGamePage> {
     super.initState();
     _level = widget.startLevel;
     _totalScore = widget.startScore;
+    _tutorialCompleted = widget.tutorialCompleted;
     _current = PlanarityGenerator.generate(
       dayKey: widget.dayKey,
       level: _level,
@@ -5342,7 +5517,8 @@ class _PlanarityGamePageState extends State<PlanarityGamePage> {
     };
   }
 
-  bool get _shouldShowInterstitialForCurrentLevel => _level % 3 == 0;
+  bool get _shouldShowInterstitialForCurrentLevel =>
+      _level > 3 && _level % 3 == 0;
 
   void _loadInterstitialAd() {
     final adUnitId = _interstitialAdUnitId;
@@ -5421,6 +5597,7 @@ class _PlanarityGamePageState extends State<PlanarityGamePage> {
         score: _totalScore,
         level: _level,
         locked: true,
+        tutorialCompleted: _tutorialCompleted,
       ),
     );
   }
@@ -5432,11 +5609,30 @@ class _PlanarityGamePageState extends State<PlanarityGamePage> {
         score: _totalScore,
         level: level ?? _level,
         locked: false,
+        tutorialCompleted: _tutorialCompleted,
       ),
     );
   }
 
-  bool _isSolved() => _countCrossings(_current.nodes, _current.edges) == 0;
+  bool get _isTutorialLevel => !_tutorialCompleted && _level <= 3;
+
+  bool get _shouldRequireMoveForSolve => _isTutorialLevel;
+
+  bool _isSolved() {
+    if (_shouldRequireMoveForSolve && _movesUsed == 0) {
+      return false;
+    }
+    return _countCrossings(_current.nodes, _current.edges) == 0;
+  }
+
+  String? _tutorialTextForLevel(int level) {
+    return switch (level) {
+      1 => 'this is a node drag it anywhere',
+      2 => 'nodes are connected by edges edges stay attached',
+      3 => 'a graph is solved when no edges cross this one is already solved',
+      _ => null,
+    };
+  }
 
   void _onPanStart(int index, DragStartDetails details) {
     if (_resolvingLevel) {
@@ -5495,6 +5691,11 @@ class _PlanarityGamePageState extends State<PlanarityGamePage> {
       });
       await _logLevelEndEvent(level: _level, success: true);
       await _logLevelUpEvent(_level + 1);
+      await widget.onLevelSolved?.call(_level);
+      final completedTutorialWithThisLevel = _isTutorialLevel && _level == 3;
+      if (completedTutorialWithThisLevel) {
+        _tutorialCompleted = true;
+      }
       final solvedNodes = List<Offset>.from(_current.nodes);
       final solvedEdges = List<Edge>.from(_current.edges);
       await _showInterstitialAdIfNeeded();
@@ -5548,6 +5749,7 @@ class _PlanarityGamePageState extends State<PlanarityGamePage> {
       _current.nodes,
       _current.edges,
     );
+    final tutorialText = _tutorialTextForLevel(_level);
 
     return Scaffold(
       body: SafeArea(
@@ -5602,6 +5804,18 @@ class _PlanarityGamePageState extends State<PlanarityGamePage> {
                   ).colorScheme.onSurface.withOpacity(0.75),
                 ),
               ),
+              if (_isTutorialLevel && tutorialText != null) ...[
+                const SizedBox(height: 8),
+                Text(
+                  tutorialText,
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.onSurface.withValues(alpha: 0.72),
+                  ),
+                ),
+              ],
               const SizedBox(height: 18),
               Row(
                 mainAxisAlignment: MainAxisAlignment.center,
@@ -6495,6 +6709,11 @@ class PlanarityLevel {
 
 class PlanarityGenerator {
   static PlanarityLevel generate({required String dayKey, required int level}) {
+    final tutorialLevel = _generateTutorialLevel(level);
+    if (tutorialLevel != null) {
+      return tutorialLevel;
+    }
+
     final nodeCount = max(2, level);
     final structureRandom = _DeterministicRandom(
       _stableSeed(dayKey, nodeCount),
@@ -6516,6 +6735,25 @@ class PlanarityGenerator {
     }
 
     return PlanarityLevel(nodes: scattered, edges: edges);
+  }
+
+  static PlanarityLevel? _generateTutorialLevel(int level) {
+    return switch (level) {
+      1 => PlanarityLevel(nodes: [const Offset(180, 240)], edges: const []),
+      2 => PlanarityLevel(
+        nodes: [const Offset(120, 240), const Offset(240, 240)],
+        edges: const [Edge(0, 1)],
+      ),
+      3 => PlanarityLevel(
+        nodes: [
+          const Offset(180, 120),
+          const Offset(90, 280),
+          const Offset(270, 280),
+        ],
+        edges: const [Edge(0, 1), Edge(1, 2), Edge(0, 2)],
+      ),
+      _ => null,
+    };
   }
 
   static List<Offset> _scatterNodes(int n, _DeterministicRandom random) {
@@ -6671,12 +6909,14 @@ class GameSessionResult {
     required this.score,
     required this.level,
     required this.locked,
+    required this.tutorialCompleted,
   });
 
   final String dayKey;
   final int score;
   final int level;
   final bool locked;
+  final bool tutorialCompleted;
 }
 
 int scoreForSolvedLevel({required int level, required int movesUsed}) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5501,6 +5501,22 @@ class _PlanarityGamePageState extends State<PlanarityGamePage> {
     unawaited(_logLevelStartEvent(_level));
   }
 
+  void _restartCurrentGraph() {
+    if (_resolvingLevel) {
+      return;
+    }
+    setState(() {
+      _movesUsed = 0;
+      _activeNode = null;
+      _dragStart = null;
+      _current = PlanarityGenerator.generate(
+        dayKey: widget.dayKey,
+        level: _level,
+      );
+      _needsCentering = true;
+    });
+  }
+
   String? get _interstitialAdUnitId {
     if (!_supportsMobileAds) {
       return null;
@@ -5783,13 +5799,23 @@ class _PlanarityGamePageState extends State<PlanarityGamePage> {
                     ),
                     Align(
                       alignment: Alignment.centerRight,
-                      child: Padding(
-                        padding: const EdgeInsets.only(right: 8),
-                        child: Text(
-                          '$_totalScore',
-                          style: Theme.of(context).textTheme.titleMedium
-                              ?.copyWith(fontWeight: FontWeight.w600),
-                        ),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          IconButton(
+                            onPressed: _restartCurrentGraph,
+                            icon: const Icon(Icons.restart_alt, size: 22),
+                            tooltip: 'restart',
+                          ),
+                          Padding(
+                            padding: const EdgeInsets.only(right: 8),
+                            child: Text(
+                              '$_totalScore',
+                              style: Theme.of(context).textTheme.titleMedium
+                                  ?.copyWith(fontWeight: FontWeight.w600),
+                            ),
+                          ),
+                        ],
                       ),
                     ),
                   ],

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -11,6 +11,7 @@ import firebase_analytics
 import firebase_auth
 import firebase_core
 import google_sign_in_ios
+import in_app_review
 import share_plus
 import shared_preferences_foundation
 import sign_in_with_apple
@@ -24,6 +25,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
+  InAppReviewPlugin.register(with: registry.registrar(forPlugin: "InAppReviewPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SignInWithApplePlugin.register(with: registry.registrar(forPlugin: "SignInWithApplePlugin"))

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1454,6 +1454,8 @@ PODS:
   - GTMSessionFetcher/Core (3.5.0)
   - GTMSessionFetcher/Full (3.5.0):
     - GTMSessionFetcher/Core
+  - in_app_review (2.0.0):
+    - FlutterMacOS
   - leveldb-library (1.22.6)
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
@@ -1465,6 +1467,8 @@ PODS:
     - FlutterMacOS
   - shared_preferences_foundation (0.0.1):
     - Flutter
+    - FlutterMacOS
+  - sign_in_with_apple (0.0.1):
     - FlutterMacOS
   - url_launcher_macos (0.0.1):
     - FlutterMacOS
@@ -1480,8 +1484,10 @@ DEPENDENCIES:
   - firebase_core (from `Flutter/ephemeral/.symlinks/plugins/firebase_core/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - google_sign_in_ios (from `Flutter/ephemeral/.symlinks/plugins/google_sign_in_ios/darwin`)
+  - in_app_review (from `Flutter/ephemeral/.symlinks/plugins/in_app_review/macos`)
   - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
   - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - sign_in_with_apple (from `Flutter/ephemeral/.symlinks/plugins/sign_in_with_apple/macos`)
   - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
   - webview_flutter_wkwebview (from `Flutter/ephemeral/.symlinks/plugins/webview_flutter_wkwebview/darwin`)
 
@@ -1529,10 +1535,14 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral
   google_sign_in_ios:
     :path: Flutter/ephemeral/.symlinks/plugins/google_sign_in_ios/darwin
+  in_app_review:
+    :path: Flutter/ephemeral/.symlinks/plugins/in_app_review/macos
   share_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/share_plus/macos
   shared_preferences_foundation:
     :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
+  sign_in_with_apple:
+    :path: Flutter/ephemeral/.symlinks/plugins/sign_in_with_apple/macos
   url_launcher_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
   webview_flutter_wkwebview:
@@ -1569,11 +1579,13 @@ SPEC CHECKSUMS:
   gRPC-Core: 860978b7db482de8b4f5e10677216309b5ff6330
   GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
+  in_app_review: 866c9b17c87a7b46a395bda43f5d3ca02deb585a
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   share_plus: 1fa619de8392a4398bfaf176d441853922614e89
   shared_preferences_foundation: 5086985c1d43c5ba4d5e69a4e8083a389e2909e6
+  sign_in_with_apple: a9e97e744e8edc36aefc2723111f652102a7a727
   url_launcher_macos: 175a54c831f4375a6cf895875f716ee5af3888ce
   webview_flutter_wkwebview: 29eb20d43355b48fe7d07113835b9128f84e3af4
 

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -578,7 +578,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.5;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -598,6 +598,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = A4495KV2T9;
 				INFOPLIST_FILE = Runner/Info.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.puzzle-games";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -662,7 +663,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.5;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -712,7 +713,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.5;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -732,6 +733,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = A4495KV2T9;
 				INFOPLIST_FILE = Runner/Info.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.puzzle-games";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -754,6 +756,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = A4495KV2T9;
 				INFOPLIST_FILE = Runner/Info.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.puzzle-games";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -421,6 +421,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.0"
+  in_app_review:
+    dependency: "direct main"
+    description:
+      name: in_app_review
+      sha256: "364db0c160b37fe7fad9cdaa18f968473924b17368869010af902760421b6bf8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.12"
+  in_app_review_platform_interface:
+    dependency: transitive
+    description:
+      name: in_app_review_platform_interface
+      sha256: fed2c755f2125caa9ae10495a3c163aa7fab5af3585a9c62ef4a6920c5b45f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.5"
   intl:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   font_awesome_flutter: ^10.10.0
   google_mobile_ads: ^7.0.0
   google_sign_in: ^7.2.0
+  in_app_review: ^2.0.10
   qr_flutter: ^4.1.0
   shared_preferences: ^2.5.3
   share_plus: ^11.1.0

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -205,6 +205,54 @@ void main() {
     );
   });
 
+  test('daily score ranking uses competition rank and top winner ties', () {
+    const entries = [
+      DailyScoreSnapshotEntry(uid: 'ada', displayName: 'ada', score: 42),
+      DailyScoreSnapshotEntry(uid: 'grace', displayName: 'grace', score: 57),
+      DailyScoreSnapshotEntry(
+        uid: 'katherine',
+        displayName: 'katherine',
+        score: 57,
+      ),
+      DailyScoreSnapshotEntry(
+        uid: 'dorothy',
+        displayName: 'dorothy',
+        score: 12,
+      ),
+    ];
+
+    expect(dailyScoreRankFor(entries, 'ada'), 3);
+    expect(dailyScoreRankFor(entries, 'grace'), 1);
+    expect(previousDayWinnerIds(entries), {'grace', 'katherine'});
+  });
+
+  test('ranking summary is shown once for a previous played day', () {
+    expect(
+      shouldShowRankingSummary(
+        todayKey: '2026-05-28',
+        previousLastPlayed: '2026-05-27',
+        lastRankingSummaryShownFor: null,
+      ),
+      isTrue,
+    );
+    expect(
+      shouldShowRankingSummary(
+        todayKey: '2026-05-28',
+        previousLastPlayed: '2026-05-27',
+        lastRankingSummaryShownFor: '2026-05-27',
+      ),
+      isFalse,
+    );
+    expect(
+      shouldShowRankingSummary(
+        todayKey: '2026-05-28',
+        previousLastPlayed: '2026-05-28',
+        lastRankingSummaryShownFor: null,
+      ),
+      isFalse,
+    );
+  });
+
   testWidgets('Home page shows mobile leaderboard with global default', (
     WidgetTester tester,
   ) async {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -146,6 +146,26 @@ void main() {
     expect(find.text('this is a node drag it anywhere'), findsOneWidget);
   });
 
+  testWidgets('Game page shows a restart graph button', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: PlanarityGamePage(
+          dayKey: '2026-03-18',
+          startLevel: 4,
+          startScore: 0,
+          tutorialCompleted: true,
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.byIcon(Icons.restart_alt), findsOneWidget);
+  });
+
   test('App Store review prompt requires iOS consecutive signed-in play', () {
     expect(
       shouldPromptForAppStoreReview(

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -63,20 +63,8 @@ void main() {
         dayKey: '2026-03-18',
         level: 6,
       );
-      final equivalentNodeCount = PlanarityGenerator.generate(
-        dayKey: '2026-03-18',
-        level: 2,
-      );
-      final equivalentNodeCountAgain = PlanarityGenerator.generate(
-        dayKey: '2026-03-18',
-        level: 1,
-      );
 
       expect(_graphSignature(first), _graphSignature(second));
-      expect(
-        _graphSignature(equivalentNodeCount),
-        _graphSignature(equivalentNodeCountAgain),
-      );
     },
   );
 
@@ -98,6 +86,122 @@ void main() {
     expect(
       _graphSignature(baseline),
       isNot(_graphSignature(differentNodeCount)),
+    );
+  });
+
+  test('tutorial graph generation uses one two and three node lessons', () {
+    final graphOne = PlanarityGenerator.generate(
+      dayKey: '2026-03-18',
+      level: 1,
+    );
+    final graphTwo = PlanarityGenerator.generate(
+      dayKey: '2026-03-18',
+      level: 2,
+    );
+    final graphThree = PlanarityGenerator.generate(
+      dayKey: '2026-03-18',
+      level: 3,
+    );
+
+    expect(graphOne.nodes, hasLength(1));
+    expect(graphOne.edges, isEmpty);
+    expect(graphTwo.nodes, hasLength(2));
+    expect(graphTwo.edges, [const Edge(0, 1)]);
+    expect(graphThree.nodes, hasLength(3));
+    expect(graphThree.edges, hasLength(3));
+  });
+
+  testWidgets('First-time local guests start with the tutorial', (
+    WidgetTester tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({});
+
+    await tester.pumpWidget(const PlanarityApp());
+    await tester.pump(const Duration(milliseconds: 100));
+    await tester.tap(find.text('start'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('this is a node drag it anywhere'), findsOneWidget);
+    expect(find.text('untangle the graph in 1 move'), findsOneWidget);
+  });
+
+  testWidgets('Existing no-progress profiles still start with the tutorial', (
+    WidgetTester tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({
+      'local_guest_user_document': jsonEncode({
+        'currentLevel': 4,
+        'lastPlayed': '',
+        'locked': false,
+        'lifetimeScore': 0,
+        'score': 0,
+      }),
+    });
+
+    await tester.pumpWidget(const PlanarityApp());
+    await tester.pump(const Duration(milliseconds: 100));
+    await tester.tap(find.text('start'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('this is a node drag it anywhere'), findsOneWidget);
+  });
+
+  test('App Store review prompt requires iOS consecutive signed-in play', () {
+    expect(
+      shouldPromptForAppStoreReview(
+        platform: TargetPlatform.iOS,
+        isWeb: false,
+        signedIn: true,
+        previousLastPlayed: '2026-05-27',
+        todayKey: '2026-05-28',
+        appStoreReviewPromptedAt: null,
+      ),
+      isTrue,
+    );
+
+    expect(
+      shouldPromptForAppStoreReview(
+        platform: TargetPlatform.android,
+        isWeb: false,
+        signedIn: true,
+        previousLastPlayed: '2026-05-27',
+        todayKey: '2026-05-28',
+        appStoreReviewPromptedAt: null,
+      ),
+      isFalse,
+    );
+    expect(
+      shouldPromptForAppStoreReview(
+        platform: TargetPlatform.iOS,
+        isWeb: false,
+        signedIn: false,
+        previousLastPlayed: '2026-05-27',
+        todayKey: '2026-05-28',
+        appStoreReviewPromptedAt: null,
+      ),
+      isFalse,
+    );
+    expect(
+      shouldPromptForAppStoreReview(
+        platform: TargetPlatform.iOS,
+        isWeb: false,
+        signedIn: true,
+        previousLastPlayed: '2026-05-26',
+        todayKey: '2026-05-28',
+        appStoreReviewPromptedAt: null,
+      ),
+      isFalse,
+    );
+    expect(
+      shouldPromptForAppStoreReview(
+        platform: TargetPlatform.iOS,
+        isWeb: false,
+        signedIn: true,
+        previousLastPlayed: '2026-05-27',
+        todayKey: '2026-05-28',
+        appStoreReviewPromptedAt: '2026-05-28',
+      ),
+      isFalse,
     );
   });
 


### PR DESCRIPTION
Closes #84
Closes #91

## Summary
- add first-time tutorial levels 1, 2, and 3 with persisted tutorial completion
- prompt eligible signed-in iOS users for an App Store review after solving graph 5
- update Firestore user rules for tutorial and review prompt state

## Verification
- flutter test --no-test-assets
- flutter analyze --no-fatal-infos
- flutter build web